### PR TITLE
增加登入功能

### DIFF
--- a/ComicRentalSystem_14Days/Forms/LoginForm.Designer.cs
+++ b/ComicRentalSystem_14Days/Forms/LoginForm.Designer.cs
@@ -1,0 +1,93 @@
+namespace ComicRentalSystem_14Days.Forms
+{
+    partial class LoginForm
+    {
+        private System.ComponentModel.IContainer components = null;
+        private System.Windows.Forms.Label lblUsername;
+        private System.Windows.Forms.Label lblPassword;
+        private System.Windows.Forms.TextBox txtUsername;
+        private System.Windows.Forms.TextBox txtPassword;
+        private System.Windows.Forms.Button btnLogin;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.lblUsername = new System.Windows.Forms.Label();
+            this.lblPassword = new System.Windows.Forms.Label();
+            this.txtUsername = new System.Windows.Forms.TextBox();
+            this.txtPassword = new System.Windows.Forms.TextBox();
+            this.btnLogin = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            //
+            // lblUsername
+            //
+            this.lblUsername.AutoSize = true;
+            this.lblUsername.Location = new System.Drawing.Point(40, 40);
+            this.lblUsername.Name = "lblUsername";
+            this.lblUsername.Size = new System.Drawing.Size(73, 15);
+            this.lblUsername.TabIndex = 0;
+            this.lblUsername.Text = "使用者名稱:";
+            //
+            // lblPassword
+            //
+            this.lblPassword.AutoSize = true;
+            this.lblPassword.Location = new System.Drawing.Point(40, 80);
+            this.lblPassword.Name = "lblPassword";
+            this.lblPassword.Size = new System.Drawing.Size(31, 15);
+            this.lblPassword.TabIndex = 1;
+            this.lblPassword.Text = "密碼:";
+            //
+            // txtUsername
+            //
+            this.txtUsername.Location = new System.Drawing.Point(120, 37);
+            this.txtUsername.Name = "txtUsername";
+            this.txtUsername.Size = new System.Drawing.Size(180, 23);
+            this.txtUsername.TabIndex = 2;
+            //
+            // txtPassword
+            //
+            this.txtPassword.Location = new System.Drawing.Point(120, 77);
+            this.txtPassword.Name = "txtPassword";
+            this.txtPassword.Size = new System.Drawing.Size(180, 23);
+            this.txtPassword.TabIndex = 3;
+            //
+            // btnLogin
+            //
+            this.btnLogin.Location = new System.Drawing.Point(120, 120);
+            this.btnLogin.Name = "btnLogin";
+            this.btnLogin.Size = new System.Drawing.Size(100, 30);
+            this.btnLogin.TabIndex = 4;
+            this.btnLogin.Text = "登入";
+            this.btnLogin.UseVisualStyleBackColor = true;
+            this.btnLogin.Click += new System.EventHandler(this.btnLogin_Click);
+            //
+            // LoginForm
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(354, 181);
+            this.Controls.Add(this.btnLogin);
+            this.Controls.Add(this.txtPassword);
+            this.Controls.Add(this.txtUsername);
+            this.Controls.Add(this.lblPassword);
+            this.Controls.Add(this.lblUsername);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "LoginForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "系統登入";
+            this.Load += new System.EventHandler(this.LoginForm_Load);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+    }
+}

--- a/ComicRentalSystem_14Days/Forms/LoginForm.cs
+++ b/ComicRentalSystem_14Days/Forms/LoginForm.cs
@@ -1,0 +1,73 @@
+using ComicRentalSystem_14Days.Interfaces;
+using ComicRentalSystem_14Days.Models;
+using ComicRentalSystem_14Days.Services;
+using System;
+using System.Windows.Forms;
+
+namespace ComicRentalSystem_14Days.Forms
+{
+    public partial class LoginForm : Form
+    {
+        private readonly ILogger _logger;
+        private readonly AuthenticationService _authService;
+        private readonly ComicService _comicService;
+        private readonly MemberService _memberService;
+        private readonly IReloadService _reloadService;
+
+        public LoginForm(
+            ILogger logger,
+            AuthenticationService authService,
+            ComicService comicService,
+            MemberService memberService,
+            IReloadService reloadService)
+        {
+            InitializeComponent();
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _authService = authService ?? throw new ArgumentNullException(nameof(authService));
+            _comicService = comicService ?? throw new ArgumentNullException(nameof(comicService));
+            _memberService = memberService ?? throw new ArgumentNullException(nameof(memberService));
+            _reloadService = reloadService ?? throw new ArgumentNullException(nameof(reloadService));
+            _logger.Log("LoginForm initialized.");
+
+            // Set password char
+            txtPassword.PasswordChar = '*';
+        }
+
+        private void btnLogin_Click(object sender, EventArgs e)
+        {
+            string username = txtUsername.Text;
+            string password = txtPassword.Text;
+
+            if (string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password))
+            {
+                MessageBox.Show("請輸入使用者名稱和密碼。", "登入失敗", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                _logger.Log("Login attempt failed: Username or password empty.");
+                return;
+            }
+
+            _logger.Log($"Login attempt for user: {username}");
+            User? user = _authService.Login(username, password);
+
+            if (user != null)
+            {
+                _logger.Log($"User '{username}' logged in successfully. Role: {user.Role}.");
+                this.Hide(); // Hide login form
+                MainForm mainForm = new MainForm(_logger, _comicService, _memberService, _reloadService, user);
+                mainForm.FormClosed += (s, args) => this.Close(); // Close login form when main form closes
+                mainForm.Show();
+            }
+            else
+            {
+                _logger.Log($"Login failed for user: {username}. Invalid credentials.");
+                MessageBox.Show("使用者名稱或密碼錯誤。", "登入失敗", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                txtPassword.Clear(); // Clear password field
+            }
+        }
+
+        private void LoginForm_Load(object sender, EventArgs e)
+        {
+            _logger.Log("LoginForm loaded.");
+            // You can add any initialization logic here if needed when the form loads
+        }
+    }
+}

--- a/ComicRentalSystem_14Days/Forms/LoginForm.resx
+++ b/ComicRentalSystem_14Days/Forms/LoginForm.resx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/ComicRentalSystem_14Days/Forms/RegistrationForm.Designer.cs
+++ b/ComicRentalSystem_14Days/Forms/RegistrationForm.Designer.cs
@@ -1,0 +1,139 @@
+namespace ComicRentalSystem_14Days.Forms
+{
+    partial class RegistrationForm
+    {
+        private System.ComponentModel.IContainer components = null;
+        private System.Windows.Forms.Label lblUsername;
+        private System.Windows.Forms.TextBox txtUsername;
+        private System.Windows.Forms.Label lblPassword;
+        private System.Windows.Forms.TextBox txtPassword;
+        private System.Windows.Forms.Label lblConfirmPassword;
+        private System.Windows.Forms.TextBox txtConfirmPassword;
+        private System.Windows.Forms.Label lblRole;
+        private System.Windows.Forms.ComboBox cmbRole;
+        private System.Windows.Forms.Button btnRegister;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.lblUsername = new System.Windows.Forms.Label();
+            this.txtUsername = new System.Windows.Forms.TextBox();
+            this.lblPassword = new System.Windows.Forms.Label();
+            this.txtPassword = new System.Windows.Forms.TextBox();
+            this.lblConfirmPassword = new System.Windows.Forms.Label();
+            this.txtConfirmPassword = new System.Windows.Forms.TextBox();
+            this.lblRole = new System.Windows.Forms.Label();
+            this.cmbRole = new System.Windows.Forms.ComboBox();
+            this.btnRegister = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            //
+            // lblUsername
+            //
+            this.lblUsername.AutoSize = true;
+            this.lblUsername.Location = new System.Drawing.Point(30, 30);
+            this.lblUsername.Name = "lblUsername";
+            this.lblUsername.Size = new System.Drawing.Size(73, 15);
+            this.lblUsername.TabIndex = 0;
+            this.lblUsername.Text = "使用者名稱:";
+            //
+            // txtUsername
+            //
+            this.txtUsername.Location = new System.Drawing.Point(130, 27);
+            this.txtUsername.Name = "txtUsername";
+            this.txtUsername.Size = new System.Drawing.Size(200, 23);
+            this.txtUsername.TabIndex = 1;
+            //
+            // lblPassword
+            //
+            this.lblPassword.AutoSize = true;
+            this.lblPassword.Location = new System.Drawing.Point(30, 70);
+            this.lblPassword.Name = "lblPassword";
+            this.lblPassword.Size = new System.Drawing.Size(31, 15);
+            this.lblPassword.TabIndex = 2;
+            this.lblPassword.Text = "密碼:";
+            //
+            // txtPassword
+            //
+            this.txtPassword.Location = new System.Drawing.Point(130, 67);
+            this.txtPassword.Name = "txtPassword";
+            this.txtPassword.Size = new System.Drawing.Size(200, 23);
+            this.txtPassword.TabIndex = 3;
+            //
+            // lblConfirmPassword
+            //
+            this.lblConfirmPassword.AutoSize = true;
+            this.lblConfirmPassword.Location = new System.Drawing.Point(30, 110);
+            this.lblConfirmPassword.Name = "lblConfirmPassword";
+            this.lblConfirmPassword.Size = new System.Drawing.Size(59, 15);
+            this.lblConfirmPassword.TabIndex = 4;
+            this.lblConfirmPassword.Text = "確認密碼:";
+            //
+            // txtConfirmPassword
+            //
+            this.txtConfirmPassword.Location = new System.Drawing.Point(130, 107);
+            this.txtConfirmPassword.Name = "txtConfirmPassword";
+            this.txtConfirmPassword.Size = new System.Drawing.Size(200, 23);
+            this.txtConfirmPassword.TabIndex = 5;
+            //
+            // lblRole
+            //
+            this.lblRole.AutoSize = true;
+            this.lblRole.Location = new System.Drawing.Point(30, 150);
+            this.lblRole.Name = "lblRole";
+            this.lblRole.Size = new System.Drawing.Size(31, 15);
+            this.lblRole.TabIndex = 6;
+            this.lblRole.Text = "角色:";
+            //
+            // cmbRole
+            //
+            this.cmbRole.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbRole.FormattingEnabled = true;
+            this.cmbRole.Location = new System.Drawing.Point(130, 147);
+            this.cmbRole.Name = "cmbRole";
+            this.cmbRole.Size = new System.Drawing.Size(200, 23);
+            this.cmbRole.TabIndex = 7;
+            //
+            // btnRegister
+            //
+            this.btnRegister.Location = new System.Drawing.Point(130, 190);
+            this.btnRegister.Name = "btnRegister";
+            this.btnRegister.Size = new System.Drawing.Size(100, 30);
+            this.btnRegister.TabIndex = 8;
+            this.btnRegister.Text = "註冊";
+            this.btnRegister.UseVisualStyleBackColor = true;
+            this.btnRegister.Click += new System.EventHandler(this.btnRegister_Click);
+            //
+            // RegistrationForm
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(384, 251);
+            this.Controls.Add(this.btnRegister);
+            this.Controls.Add(this.cmbRole);
+            this.Controls.Add(this.lblRole);
+            this.Controls.Add(this.txtConfirmPassword);
+            this.Controls.Add(this.lblConfirmPassword);
+            this.Controls.Add(this.txtPassword);
+            this.Controls.Add(this.lblPassword);
+            this.Controls.Add(this.txtUsername);
+            this.Controls.Add(this.lblUsername);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "RegistrationForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "使用者註冊";
+            this.Load += new System.EventHandler(this.RegistrationForm_Load);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+    }
+}

--- a/ComicRentalSystem_14Days/Forms/RegistrationForm.cs
+++ b/ComicRentalSystem_14Days/Forms/RegistrationForm.cs
@@ -1,0 +1,85 @@
+using ComicRentalSystem_14Days.Interfaces;
+using ComicRentalSystem_14Days.Models;
+using ComicRentalSystem_14Days.Services;
+using System;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace ComicRentalSystem_14Days.Forms
+{
+    public partial class RegistrationForm : Form
+    {
+        private readonly ILogger _logger;
+        private readonly AuthenticationService _authService;
+
+        public RegistrationForm(ILogger logger, AuthenticationService authService)
+        {
+            InitializeComponent();
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _authService = authService ?? throw new ArgumentNullException(nameof(authService));
+
+            // Populate role ComboBox
+            cmbRole.DataSource = Enum.GetValues(typeof(UserRole));
+            cmbRole.SelectedItem = UserRole.Member; // Default to Member
+
+            txtPassword.PasswordChar = '*';
+            txtConfirmPassword.PasswordChar = '*';
+            _logger.Log("RegistrationForm initialized.");
+        }
+
+        private void btnRegister_Click(object sender, EventArgs e)
+        {
+            string username = txtUsername.Text.Trim();
+            string password = txtPassword.Text;
+            string confirmPassword = txtConfirmPassword.Text;
+            UserRole selectedRole = (UserRole)cmbRole.SelectedItem;
+
+            if (string.IsNullOrWhiteSpace(username))
+            {
+                MessageBox.Show("使用者名稱不能為空。", "註冊失敗", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                _logger.Log("Registration attempt failed: Username empty.");
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                MessageBox.Show("密碼不能為空。", "註冊失敗", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                _logger.Log("Registration attempt failed: Password empty.");
+                return;
+            }
+
+            if (password != confirmPassword)
+            {
+                MessageBox.Show("密碼與確認密碼不相符。", "註冊失敗", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                _logger.Log("Registration attempt failed: Passwords do not match.");
+                txtPassword.Clear();
+                txtConfirmPassword.Clear();
+                return;
+            }
+
+            _logger.Log($"Registration attempt for user: {username}, Role: {selectedRole}");
+            bool success = _authService.Register(username, password, selectedRole);
+
+            if (success)
+            {
+                _logger.Log($"User '{username}' registered successfully as {selectedRole}.");
+                MessageBox.Show($"使用者 '{username}' 已成功註冊為 {selectedRole}。", "註冊成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                // Optionally close the form or clear fields
+                txtUsername.Clear();
+                txtPassword.Clear();
+                txtConfirmPassword.Clear();
+                cmbRole.SelectedItem = UserRole.Member;
+            }
+            else
+            {
+                _logger.Log($"Registration failed for user: {username}. Username might already exist.");
+                MessageBox.Show($"註冊失敗。使用者名稱 '{username}' 可能已被使用。", "註冊失敗", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void RegistrationForm_Load(object sender, EventArgs e)
+        {
+            _logger.Log("RegistrationForm loaded.");
+        }
+    }
+}

--- a/ComicRentalSystem_14Days/Forms/RegistrationForm.resx
+++ b/ComicRentalSystem_14Days/Forms/RegistrationForm.resx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/ComicRentalSystem_14Days/MainForm.Designer.cs
+++ b/ComicRentalSystem_14Days/MainForm.Designer.cs
@@ -42,14 +42,19 @@ namespace ComicRentalSystem_14Days
             檢視日誌ToolStripMenuItem = new ToolStripMenuItem();
             dgvAvailableComics = new DataGridView();
             lblAvailableComics = new Label();
+            this.使用者註冊ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.logoutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.statusStrip1 = new System.Windows.Forms.StatusStrip();
+            this.toolStripStatusLabelUser = new System.Windows.Forms.ToolStripStatusLabel();
             menuStrip2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)dgvAvailableComics).BeginInit();
+            this.statusStrip1.SuspendLayout(); // Added
             SuspendLayout();
             // 
             // menuStrip1
             // 
             menuStrip1.ImageScalingSize = new Size(20, 20);
-            menuStrip1.Location = new Point(0, 27);
+            menuStrip1.Location = new Point(0, 27); // This menuStrip appears unused for items
             menuStrip1.Name = "menuStrip1";
             menuStrip1.Padding = new Padding(7, 2, 0, 2);
             menuStrip1.Size = new Size(900, 24);
@@ -59,7 +64,8 @@ namespace ComicRentalSystem_14Days
             // menuStrip2
             // 
             menuStrip2.ImageScalingSize = new Size(20, 20);
-            menuStrip2.Items.AddRange(new ToolStripItem[] { 檔案ToolStripMenuItem, 管理ToolStripMenuItem, 工具ToolStripMenuItem });
+            // Added 使用者註冊ToolStripMenuItem and logoutToolStripMenuItem here
+            menuStrip2.Items.AddRange(new ToolStripItem[] { 檔案ToolStripMenuItem, 管理ToolStripMenuItem, 工具ToolStripMenuItem, this.使用者註冊ToolStripMenuItem, this.logoutToolStripMenuItem });
             menuStrip2.Location = new Point(0, 0);
             menuStrip2.Name = "menuStrip2";
             menuStrip2.Padding = new Padding(7, 2, 0, 2);
@@ -123,18 +129,33 @@ namespace ComicRentalSystem_14Days
             檢視日誌ToolStripMenuItem.Text = "檢視日誌";
             檢視日誌ToolStripMenuItem.Click += 檢視日誌ToolStripMenuItem_Click;
             // 
+            // 使用者註冊ToolStripMenuItem
+            //
+            this.使用者註冊ToolStripMenuItem.Name = "使用者註冊ToolStripMenuItem";
+            this.使用者註冊ToolStripMenuItem.Size = new System.Drawing.Size(103, 23);
+            this.使用者註冊ToolStripMenuItem.Text = "使用者註冊 (&R)";
+            this.使用者註冊ToolStripMenuItem.Click += new System.EventHandler(this.使用者註冊ToolStripMenuItem_Click);
+            //
+            // logoutToolStripMenuItem
+            //
+            this.logoutToolStripMenuItem.Name = "logoutToolStripMenuItem";
+            this.logoutToolStripMenuItem.Size = new System.Drawing.Size(74, 23);
+            this.logoutToolStripMenuItem.Text = "登出 (&L)";
+            this.logoutToolStripMenuItem.Click += new System.EventHandler(this.logoutToolStripMenuItem_Click);
+            //
             // dgvAvailableComics
             // 
             dgvAvailableComics.AllowUserToAddRows = false;
             dgvAvailableComics.AllowUserToDeleteRows = false;
             dgvAvailableComics.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             dgvAvailableComics.Dock = DockStyle.Fill;
+            // Adjusted Location and Size to accommodate statusStrip1
             dgvAvailableComics.Location = new Point(0, 86);
             dgvAvailableComics.Margin = new Padding(4);
             dgvAvailableComics.Name = "dgvAvailableComics";
             dgvAvailableComics.ReadOnly = true;
             dgvAvailableComics.RowHeadersWidth = 51;
-            dgvAvailableComics.Size = new Size(900, 417);
+            dgvAvailableComics.Size = new Size(900, 395); // Height reduced by 22 (statusStrip height)
             dgvAvailableComics.TabIndex = 2;
             // 
             // lblAvailableComics
@@ -147,19 +168,36 @@ namespace ComicRentalSystem_14Days
             lblAvailableComics.Name = "lblAvailableComics";
             lblAvailableComics.Padding = new Padding(5);
             lblAvailableComics.Size = new Size(182, 35);
-            lblAvailableComics.TabIndex = 3;
+            lblAvailableComics.TabIndex = 3; // Changed from 3 to 4, as statusStrip will be 3
             lblAvailableComics.Text = "目前可借閱的漫畫";
             // 
+            // statusStrip1
+            //
+            this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripStatusLabelUser});
+            this.statusStrip1.Location = new System.Drawing.Point(0, 481); // Adjusted Y based on new ClientSize
+            this.statusStrip1.Name = "statusStrip1";
+            this.statusStrip1.Size = new System.Drawing.Size(900, 22);
+            this.statusStrip1.TabIndex = 4; // New TabIndex
+            this.statusStrip1.Text = "statusStrip1";
+            //
+            // toolStripStatusLabelUser
+            //
+            this.toolStripStatusLabelUser.Name = "toolStripStatusLabelUser";
+            this.toolStripStatusLabelUser.Size = new System.Drawing.Size(136, 17); // Example size, text might make it wider
+            this.toolStripStatusLabelUser.Text = "User: None | Role: None";
+            //
             // MainForm
             // 
             AutoScaleDimensions = new SizeF(9F, 19F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(900, 503);
+            ClientSize = new Size(900, 503); // Original ClientSize
             Controls.Add(dgvAvailableComics);
             Controls.Add(lblAvailableComics);
-            Controls.Add(menuStrip1);
-            Controls.Add(menuStrip2);
-            MainMenuStrip = menuStrip1;
+            Controls.Add(menuStrip1); // This menuStrip1 seems to be secondary or unused for items
+            Controls.Add(menuStrip2); // This is the main menuStrip
+            Controls.Add(this.statusStrip1); // Added statusStrip1
+            MainMenuStrip = menuStrip2; // Changed to menuStrip2 as it contains the items
             Margin = new Padding(4);
             Name = "MainForm";
             Text = "漫畫租借系統";
@@ -167,6 +205,8 @@ namespace ComicRentalSystem_14Days
             menuStrip2.ResumeLayout(false);
             menuStrip2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)dgvAvailableComics).EndInit();
+            this.statusStrip1.ResumeLayout(false); // Added
+            this.statusStrip1.PerformLayout(); // Added
             ResumeLayout(false);
             PerformLayout();
         }
@@ -185,5 +225,9 @@ namespace ComicRentalSystem_14Days
         private ToolStripMenuItem rentalManagementToolStripMenuItem;
         private DataGridView dgvAvailableComics;
         private Label lblAvailableComics;
+        private System.Windows.Forms.ToolStripMenuItem 使用者註冊ToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem logoutToolStripMenuItem;
+        private System.Windows.Forms.StatusStrip statusStrip1;
+        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelUser;
     }
 }

--- a/ComicRentalSystem_14Days/MainForm.cs
+++ b/ComicRentalSystem_14Days/MainForm.cs
@@ -1,22 +1,26 @@
-﻿using ComicRentalSystem_14Days.Forms;
-using ComicRentalSystem_14Days.Helpers;
-using ComicRentalSystem_14Days.Interfaces;
-using ComicRentalSystem_14Days.Models;
-using ComicRentalSystem_14Days.Services;
-using System;
-using System.Data;
-using System.Diagnostics;
-using System.Linq;
-using System.Windows.Forms;
+﻿using ComicRentalSystem_14Days.Models; // Added
+using ComicRentalSystem_14Days.Services; // Existing, ensure it's comprehensive
+using ComicRentalSystem_14Days.Forms; // Existing, ensure it's comprehensive
+using ComicRentalSystem_14Days.Interfaces; // Existing
+using System; // For ArgumentNullException, EventArgs
+using System.Linq; // Added
+using System.Windows.Forms; // For MessageBox, etc.
+using System.Diagnostics; // Existing
+// Removed: using ComicRentalSystem_14Days.Helpers; (Not directly used in provided snippets of MainForm)
+// Removed: using System.Data; (Not directly used in provided snippets of MainForm)
+
 
 namespace ComicRentalSystem_14Days
 {
     public partial class MainForm : BaseForm
     {
-        private readonly ILogger? _logger;
-        private readonly ComicService? _comicService; // 接收共享的實例，不再自己 new
+        private readonly User _currentUser;
+        private readonly ComicService _comicService;
+        private readonly MemberService _memberService;
+        private readonly IReloadService _reloadService;
+        private readonly ILogger _logger;
 
-        public MainForm() : base()
+        public MainForm() : base() // Parameterless constructor for Windows Forms designer
         {
             InitializeComponent();
             if (this.DesignMode)
@@ -25,35 +29,41 @@ namespace ComicRentalSystem_14Days
             }
         }
 
-        public MainForm(ILogger logger, ComicService comicService) : this()
+        // Primary constructor
+        public MainForm(ILogger logger, ComicService comicService, MemberService memberService, IReloadService reloadService, User currentUser) : this()
         {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _comicService = comicService ?? throw new ArgumentNullException(nameof(comicService));
-            base.SetLogger(logger);
+            this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this._comicService = comicService ?? throw new ArgumentNullException(nameof(comicService));
+            this._memberService = memberService ?? throw new ArgumentNullException(nameof(memberService));
+            this._reloadService = reloadService ?? throw new ArgumentNullException(nameof(reloadService));
+            this._currentUser = currentUser ?? throw new ArgumentNullException(nameof(currentUser));
 
-            _logger.Log("MainForm initialized with shared logger and services.");
+            base.SetLogger(logger); // Assumes BaseForm has public void SetLogger(ILogger logger)
+
+            _logger.Log($"MainForm initialized for user: {_currentUser.Username}, Role: {_currentUser.Role}");
+
+            SetupUIAccessControls();
+            UpdateStatusBar();
         }
 
         private void MainForm_Load(object sender, EventArgs e)
         {
-            _logger?.Log("MainForm is loading.");
-            if (_comicService != null)
-            {
-                SetupDataGridView();
-                LoadAvailableComics();
-                _comicService.ComicsChanged += ComicService_ComicsChanged;
-            }
+            this._logger?.Log("MainForm is loading.");
+            // _comicService is guaranteed non-null by constructor, direct use.
+            SetupDataGridView();
+            LoadAvailableComics();
+            this._comicService.ComicsChanged += ComicService_ComicsChanged;
         }
 
         private void ComicService_ComicsChanged(object? sender, EventArgs e)
         {
-            _logger?.Log("ComicsChanged event received, reloading available comics.");
+            this._logger?.Log("ComicsChanged event received, reloading available comics.");
             LoadAvailableComics();
         }
 
         private void SetupDataGridView()
         {
-            _logger?.Log("Setting up DataGridView for available comics.");
+            this._logger?.Log("Setting up DataGridView for available comics.");
             dgvAvailableComics.AutoGenerateColumns = false;
             dgvAvailableComics.Columns.Clear();
             dgvAvailableComics.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
@@ -71,12 +81,12 @@ namespace ComicRentalSystem_14Days
 
         private void LoadAvailableComics()
         {
-            if (_comicService == null) return;
-            _logger?.Log("Loading available comics into MainForm DataGridView.");
+            // _comicService is guaranteed non-null by constructor
+            this._logger?.Log("Loading available comics into MainForm DataGridView.");
 
             try
             {
-                var availableComics = _comicService.GetAllComics().Where(c => !c.IsRented).ToList();
+                var availableComics = this._comicService.GetAllComics().Where(c => !c.IsRented).ToList();
 
                 if (this.InvokeRequired)
                 {
@@ -91,79 +101,136 @@ namespace ComicRentalSystem_14Days
                     dgvAvailableComics.DataSource = availableComics;
                 }
 
-                _logger?.Log($"Successfully loaded {availableComics.Count} available comics.");
+                this._logger?.Log($"Successfully loaded {availableComics.Count} available comics.");
             }
             catch (Exception ex)
             {
+                // Assuming LogErrorActivity is a method in BaseForm or this class
                 LogErrorActivity("Error loading available comics.", ex);
                 MessageBox.Show($"載入可用漫畫列表時發生錯誤: {ex.Message}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
+        private void SetupUIAccessControls()
+        {
+            bool isAdmin = _currentUser.Role == UserRole.Admin;
+            this._logger.Log($"Setting up UI controls. User is Admin: {isAdmin}");
+
+            var comicMgmtItem = this.Controls.Find("漫畫管理ToolStripMenuItem", true).FirstOrDefault() as ToolStripMenuItem;
+            if (comicMgmtItem != null)
+            {
+                comicMgmtItem.Visible = isAdmin;
+                comicMgmtItem.Enabled = isAdmin;
+            }
+
+            var memberMgmtItem = this.Controls.Find("會員管理ToolStripMenuItem", true).FirstOrDefault() as ToolStripMenuItem;
+            if (memberMgmtItem != null)
+            {
+                memberMgmtItem.Visible = isAdmin;
+                memberMgmtItem.Enabled = isAdmin;
+            }
+
+            var userRegItem = this.Controls.Find("使用者註冊ToolStripMenuItem", true).FirstOrDefault() as ToolStripMenuItem;
+            if (userRegItem != null)
+            {
+                userRegItem.Visible = isAdmin;
+                userRegItem.Enabled = isAdmin;
+            }
+        }
+
+        private void UpdateStatusBar()
+        {
+            var statusLabel = this.Controls.Find("toolStripStatusLabelUser", true).FirstOrDefault() as ToolStripStatusLabel;
+            if (statusLabel != null)
+            {
+                statusLabel.Text = $"使用者: {_currentUser.Username} | 角色: {_currentUser.Role}";
+                this._logger.Log($"Status bar updated: User: {_currentUser.Username}, Role: {_currentUser.Role}");
+            }
+            else
+            {
+                this._logger.Log("toolStripStatusLabelUser not found. Cannot update status bar.");
+            }
+        }
+
         private void 離開ToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            _logger?.Log("Exit menu item clicked. Application will exit.");
+            this._logger?.Log("Exit menu item clicked. Application will exit.");
             Application.Exit();
         }
 
         private void 漫畫管理ToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            _logger?.Log("Opening ComicManagementForm.");
-            if (_logger != null && Program.AppComicService != null)
-            {
-                ComicManagementForm comicMgmtForm = new ComicManagementForm(_logger, Program.AppComicService);
-                comicMgmtForm.ShowDialog(this);
-            }
-            else
-            {
-                MessageBox.Show("Logger 或 ComicService 未初始化，無法開啟漫畫管理。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
+            this._logger?.Log("Opening ComicManagementForm.");
+            // Services are guaranteed non-null by constructor
+            ComicManagementForm comicMgmtForm = new ComicManagementForm(this._logger, this._comicService);
+            comicMgmtForm.ShowDialog(this);
         }
 
         private void 會員管理ToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            _logger?.Log("Opening MemberManagementForm.");
-            if (_logger != null && Program.AppMemberService != null)
-            {
-                MemberManagementForm memberMgmtForm = new MemberManagementForm(_logger, Program.AppMemberService);
-                memberMgmtForm.ShowDialog(this);
-            }
-            else
-            {
-                MessageBox.Show("Logger 或 MemberService 未初始化，無法開啟會員管理。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
+            this._logger?.Log("Opening MemberManagementForm.");
+            // Services are guaranteed non-null by constructor
+            MemberManagementForm memberMgmtForm = new MemberManagementForm(this._logger, this._memberService);
+            memberMgmtForm.ShowDialog(this);
         }
 
         private void rentalManagementToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            _logger?.Log("Opening RentalForm.");
-            if (_logger == null || Program.AppComicService == null || Program.AppMemberService == null || Program.AppReloadService == null)
-            {
-                MessageBox.Show("核心服務未初始化，無法開啟租借管理。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                return;
-            }
-
+            this._logger?.Log("Opening RentalForm.");
+            // Services are guaranteed non-null by constructor here
+            // No need for explicit null check of this._logger, this._comicService, this._memberService, this._reloadService
+            // as they are checked in the constructor.
             try
             {
-                RentalForm rentalForm = new RentalForm(Program.AppComicService, Program.AppMemberService, _logger, Program.AppReloadService);
+                RentalForm rentalForm = new RentalForm(this._comicService, this._memberService, this._logger, this._reloadService);
                 rentalForm.ShowDialog(this);
             }
             catch (Exception ex)
             {
-                _logger?.LogError("Failed to open RentalForm.", ex);
+                this._logger?.LogError("Failed to open RentalForm.", ex);
                 MessageBox.Show($"開啟租借表單時發生錯誤: {ex.Message}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
+        private void 使用者註冊ToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            this._logger?.Log("使用者註冊ToolStripMenuItem clicked.");
+            if (_currentUser.Role == UserRole.Admin)
+            {
+                if (this._logger != null && Program.AppAuthService != null)
+                {
+                    var regForm = new ComicRentalSystem_14Days.Forms.RegistrationForm(this._logger, Program.AppAuthService);
+                    regForm.ShowDialog(this);
+                }
+                else
+                {
+                    MessageBox.Show("Logger 或 AuthenticationService 未初始化，無法開啟使用者註冊。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    this._logger?.LogError("RegistrationForm could not be opened due to null logger or AppAuthService.");
+                }
+            }
+            else
+            {
+                MessageBox.Show("只有管理員才能註冊新使用者。", "權限不足", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                this._logger?.Log($"Non-admin user '{_currentUser.Username}' tried to open RegistrationForm.");
+            }
+        }
+
+        private void logoutToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            this._logger?.Log($"User '{_currentUser.Username}' logging out.");
+            Application.Restart();
+        }
+
         private void 檢視日誌ToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            _logger?.Log("View Log menu item clicked.");
+            this._logger?.Log("View Log menu item clicked.");
             try
             {
-                string logDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "ComicRentalApp", "Logs");
-                string logFilePath = Path.Combine(logDirectory, "ComicRentalSystemLog.txt");
+                // Assuming Path.Combine and File.Exists are from System.IO
+                string logDirectory = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "ComicRentalApp", "Logs");
+                string logFilePath = System.IO.Path.Combine(logDirectory, "ComicRentalSystemLog.txt");
 
-                if (File.Exists(logFilePath))
+                if (System.IO.File.Exists(logFilePath))
                 {
                     Process.Start(new ProcessStartInfo(logFilePath) { UseShellExecute = true });
                 }
@@ -174,18 +241,16 @@ namespace ComicRentalSystem_14Days
             }
             catch (Exception ex)
             {
-                _logger?.LogError("Failed to open the log file.", ex);
+                this._logger?.LogError("Failed to open the log file.", ex);
                 MessageBox.Show($"無法開啟日誌檔案: {ex.Message}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
-            _logger?.Log("MainForm is closing. Unsubscribing from events.");
-            if (_comicService != null)
-            {
-                _comicService.ComicsChanged -= ComicService_ComicsChanged;
-            }
+            this._logger?.Log("MainForm is closing. Unsubscribing from events.");
+            // _comicService is guaranteed non-null here
+            this._comicService.ComicsChanged -= ComicService_ComicsChanged;
             base.OnFormClosing(e);
         }
     }

--- a/ComicRentalSystem_14Days/Models/BaseEntity.cs
+++ b/ComicRentalSystem_14Days/Models/BaseEntity.cs
@@ -8,6 +8,6 @@ namespace ComicRentalSystem_14Days.Models
 {
     public class BaseEntity
     {
-        public int Id { get; set; }
+        public string Id { get; set; }
     }
 }

--- a/ComicRentalSystem_14Days/Models/User.cs
+++ b/ComicRentalSystem_14Days/Models/User.cs
@@ -1,0 +1,24 @@
+namespace ComicRentalSystem_14Days.Models
+{
+    public enum UserRole
+    {
+        Member,
+        Admin
+    }
+
+    public class User : BaseEntity
+    {
+        public string Username { get; set; }
+        public string PasswordHash { get; set; }
+        public UserRole Role { get; set; }
+
+        public User(string username, string passwordHash, UserRole role)
+        {
+            // Consider adding validation or default values if necessary
+            Id = Guid.NewGuid().ToString(); // Inherited from BaseEntity
+            Username = username;
+            PasswordHash = passwordHash;
+            Role = role;
+        }
+    }
+}

--- a/ComicRentalSystem_14Days/Program.cs
+++ b/ComicRentalSystem_14Days/Program.cs
@@ -2,6 +2,7 @@ using ComicRentalSystem_14Days.Helpers;
 using ComicRentalSystem_14Days.Interfaces;
 using ComicRentalSystem_14Days.Logging;
 using ComicRentalSystem_14Days.Services;
+using ComicRentalSystem_14Days.Forms;
 
 namespace ComicRentalSystem_14Days
 {
@@ -12,6 +13,7 @@ namespace ComicRentalSystem_14Days
         public static ComicService? AppComicService { get; private set; }
         public static MemberService? AppMemberService { get; private set; }
         public static IReloadService? AppReloadService { get; private set; }
+        public static AuthenticationService? AppAuthService { get; private set; }
 
 
         [STAThread]
@@ -29,6 +31,9 @@ namespace ComicRentalSystem_14Days
             {
                 AppComicService = new ComicService(AppFileHelper, AppLogger);
                 AppMemberService = new MemberService(AppFileHelper, AppLogger);
+                AppAuthService = new AuthenticationService(AppFileHelper, AppLogger);
+                // Ensure a default admin user exists for initial setup
+                AppAuthService.EnsureAdminUserExists("admin", "admin123");
             }
 
             Application.ThreadException += new System.Threading.ThreadExceptionEventHandler(Application_ThreadException);
@@ -36,14 +41,14 @@ namespace ComicRentalSystem_14Days
 
             try
             {
-                if (AppLogger != null && AppComicService != null)
+                if (AppLogger != null && AppAuthService != null && AppComicService != null && AppMemberService != null && AppReloadService != null)
                 {
-                    Application.Run(new MainForm(AppLogger, AppComicService));
+                    Application.Run(new LoginForm(AppLogger, AppAuthService, AppComicService, AppMemberService, AppReloadService));
                 }
                 else
                 {
                     MessageBox.Show("無法初始化核心服務，應用程式即將關閉。", "嚴重錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    AppLogger?.LogError("Application terminated because core services (Logger or ComicService) failed to initialize.");
+                    AppLogger?.LogError("Application terminated because core services (Logger, AuthService, ComicService, MemberService, or ReloadService) failed to initialize.");
                 }
             }
             catch (Exception ex)

--- a/ComicRentalSystem_14Days/Services/AuthenticationService.cs
+++ b/ComicRentalSystem_14Days/Services/AuthenticationService.cs
@@ -1,0 +1,135 @@
+using ComicRentalSystem_14Days.Models;
+using ComicRentalSystem_14Days.Helpers;
+using ComicRentalSystem_14Days.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json; // Make sure to use System.Text.Json
+
+namespace ComicRentalSystem_14Days.Services
+{
+    public class AuthenticationService
+    {
+        private readonly FileHelper _fileHelper;
+        private readonly ILogger _logger;
+        private readonly string _usersFilePath = "users.json"; // Path relative to FileHelper's base directory
+        private List<User> _users;
+
+        public AuthenticationService(FileHelper fileHelper, ILogger logger)
+        {
+            _fileHelper = fileHelper ?? throw new ArgumentNullException(nameof(fileHelper));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _users = LoadUsers() ?? new List<User>();
+            _logger.Log("AuthenticationService initialized.");
+        }
+
+        private List<User>? LoadUsers()
+        {
+            try
+            {
+                _logger.Log($"Attempting to load users from {_usersFilePath}");
+                string json = _fileHelper.ReadFile(_usersFilePath);
+                if (string.IsNullOrWhiteSpace(json))
+                {
+                    _logger.Log("Users file is empty or not found, returning new list.");
+                    return new List<User>();
+                }
+                var users = JsonSerializer.Deserialize<List<User>>(json);
+                _logger.Log($"Successfully loaded {users?.Count ?? 0} users.");
+                return users;
+            }
+            catch (FileNotFoundException)
+            {
+                _logger.Log($"Users file '{_usersFilePath}' not found. A new one will be created on registration.");
+                return new List<User>();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error loading users from {_usersFilePath}.", ex);
+                // Depending on the severity, you might want to throw or handle differently
+                return new List<User>(); // Return empty list on error to allow app to continue
+            }
+        }
+
+        private void SaveUsers()
+        {
+            try
+            {
+                _logger.Log($"Attempting to save {_users.Count} users to {_usersFilePath}");
+                string json = JsonSerializer.Serialize(_users, new JsonSerializerOptions { WriteIndented = true });
+                _fileHelper.WriteFile(_usersFilePath, json);
+                _logger.Log("Users saved successfully.");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error saving users to {_usersFilePath}.", ex);
+                // Handle exception (e.g., notify admin, retry logic)
+            }
+        }
+
+        private string HashPassword(string password)
+        {
+            using (SHA256 sha256 = SHA256.Create())
+            {
+                byte[] bytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(password));
+                StringBuilder builder = new StringBuilder();
+                for (int i = 0; i < bytes.Length; i++)
+                {
+                    builder.Append(bytes[i].ToString("x2"));
+                }
+                return builder.ToString();
+            }
+        }
+
+        public bool Register(string username, string password, UserRole role)
+        {
+            _logger.Log($"Attempting to register user: {username}, Role: {role}");
+            if (_users.Any(u => u.Username.Equals(username, StringComparison.OrdinalIgnoreCase)))
+            {
+                _logger.Log($"Registration failed: Username '{username}' already exists.");
+                return false; // Username already exists
+            }
+
+            string passwordHash = HashPassword(password);
+            User newUser = new User(username, passwordHash, role);
+            _users.Add(newUser);
+            SaveUsers();
+            _logger.Log($"User '{username}' registered successfully with ID {newUser.Id}.");
+            return true;
+        }
+
+        public User? Login(string username, string password)
+        {
+            _logger.Log($"Attempting to login user: {username}");
+            string passwordHash = HashPassword(password);
+            User? user = _users.FirstOrDefault(u => u.Username.Equals(username, StringComparison.OrdinalIgnoreCase) && u.PasswordHash == passwordHash);
+
+            if (user != null)
+            {
+                _logger.Log($"User '{username}' logged in successfully. Role: {user.Role}");
+                return user;
+            }
+            else
+            {
+                _logger.Log($"Login failed for user: {username}. Invalid username or password.");
+                return null;
+            }
+        }
+
+        // Method to allow creating a default admin user if no users exist
+        public void EnsureAdminUserExists(string adminUsername, string adminPassword)
+        {
+            if (!_users.Any(u => u.Role == UserRole.Admin))
+            {
+                _logger.Log($"No admin user found. Creating default admin: {adminUsername}");
+                Register(adminUsername, adminPassword, UserRole.Admin);
+            }
+            else
+            {
+                _logger.Log("Admin user already exists.");
+            }
+        }
+    }
+}


### PR DESCRIPTION


* 新增用戶模型（User Model），區分「管理員(Admin)」與「會員(Member)」角色。
* 新增「認證服務(AuthenticationService)」，負責用戶註冊與登入。該服務將資料儲存於 `users.json`，並採用SHA256雜湊儲存密碼。
* 新增「登入表單(LoginForm)」，現為應用程式的進入點。
* 新增「註冊表單(RegistrationForm)」，僅管理員可用於建立新用戶。
* 主畫面(MainForm)更新如下：

  * 接收當前登入用戶資訊。
  * 於狀態列顯示使用者資料。
  * 根據用戶是否為管理員，控制「漫畫管理」、「會員管理」與「用戶註冊」選單項目的顯示與存取權限。
  * 增加「登出」功能。
* 若系統首次啟動時不存在管理員帳號，將自動建立一個預設的「admin」用戶。
