### PR TITLE
I tried to fix various compilation errors based on the initial list y…

### DIFF
--- a/ComicRentalSystem_14Days/Helpers/FileHelper.cs
+++ b/ComicRentalSystem_14Days/Helpers/FileHelper.cs
@@ -37,7 +37,7 @@ namespace ComicRentalSystem_14Days.Helpers
             return Path.Combine(_baseDataPath, fileName);
         }
 
-        public List<T> ReadCsvFile<T>(string fileName, Func<string, T> parseFunc)
+        public List<T> ReadFile<T>(string fileName, Func<string, T> parseFunc)
         {
             string filePath = GetFullFilePath(fileName);
             List<T> records = new List<T>();
@@ -76,7 +76,7 @@ namespace ComicRentalSystem_14Days.Helpers
 
         // T 是要儲存的物件類型
         // toCsvFunc 是將 T 物件轉換為 CSV 字串行的函式
-        public void WriteCsvFile<T>(string fileName, IEnumerable<T> records, Func<T, string> toCsvFunc)
+        public void WriteFile<T>(string fileName, IEnumerable<T> records, Func<T, string> toCsvFunc)
         {
             string filePath = GetFullFilePath(fileName);
             try

--- a/ComicRentalSystem_14Days/Services/ComicService.cs
+++ b/ComicRentalSystem_14Days/Services/ComicService.cs
@@ -39,7 +39,7 @@ namespace ComicRentalSystem_14Days.Services
             _logger.Log($"Attempting to load comics from file: '{_comicFileName}'.");
             try
             {
-                _comics = _fileHelper.ReadCsvFile<Comic>(_comicFileName, Comic.FromCsvString);
+                _comics = _fileHelper.ReadFile<Comic>(_comicFileName, Comic.FromCsvString);
                 _logger.Log($"Successfully loaded {_comics.Count} comics from '{_comicFileName}'.");
             }
             catch (Exception ex)
@@ -54,7 +54,7 @@ namespace ComicRentalSystem_14Days.Services
             _logger.Log($"Attempting to save {_comics.Count} comics to file: '{_comicFileName}'.");
             try
             {
-                _fileHelper.WriteCsvFile<Comic>(_comicFileName, _comics, comic => comic.ToCsvString());
+                _fileHelper.WriteFile<Comic>(_comicFileName, _comics, comic => comic.ToCsvString());
                 _logger.Log($"Successfully saved {_comics.Count} comics to '{_comicFileName}'.");
                 OnComicsChanged();
             }

--- a/ComicRentalSystem_14Days/Services/MemberService.cs
+++ b/ComicRentalSystem_14Days/Services/MemberService.cs
@@ -43,7 +43,7 @@ namespace ComicRentalSystem_14Days.Services
             _logger.Log($"Attempting to load members from file: '{_memberFileName}'.");
             try
             {
-                _members = _fileHelper.ReadCsvFile<Member>(_memberFileName, Member.FromCsvString);
+                _members = _fileHelper.ReadFile<Member>(_memberFileName, Member.FromCsvString);
                 _logger.Log($"Successfully loaded {_members.Count} members from '{_memberFileName}'.");
             }
             catch (Exception ex)
@@ -58,7 +58,7 @@ namespace ComicRentalSystem_14Days.Services
             _logger.Log($"Attempting to save {_members.Count} members to file: '{_memberFileName}'.");
             try
             {
-                _fileHelper.WriteCsvFile<Member>(_memberFileName, _members, member => member.ToCsvString());
+                _fileHelper.WriteFile<Member>(_memberFileName, _members, member => member.ToCsvString());
                 _logger.Log($"Successfully saved {_members.Count} members to '{_memberFileName}'.");
                 OnMembersChanged();
             }


### PR DESCRIPTION
…ou provided.

Here's what I did:
1. I renamed methods in `FileHelper`: `ReadCsvFile` became `ReadFile`, and `WriteCsvFile` became `WriteFile`. I also updated where these methods were used. This took care of the errors stating that 'FileHelper' didn't have definitions for 'ReadFile' or 'WriteFile'.

2. I attempted to build the project to get a complete list of compiler errors, but the build failed because the current environment doesn't support Windows Desktop development.

3. Because of the build issue, I switched to a manual review process, relying on the error messages you provided.
    - I planned to look into type mismatches (like Control to ToolStripMenuItem/ToolStripStatusLabel), issues with converting and comparing strings and integers, problems with multiple entry points, and issues with Assert.AreEqual.

Challenges I faced:
- The main difficulty is that I can't build the Windows Forms project in the current Linux-based environment. This means I don't get direct feedback from the compiler, which makes it hard to confirm if my fixes work and to pinpoint the exact locations of all errors.
- I'm relying solely on the initial error messages, and some of these might not have all the necessary context or could be signs of deeper problems that are tough to diagnose without a successful build.

This update includes the changes I made to `FileHelper.cs`. I had planned to continue with a manual review for the other errors, but I couldn't finish due to the environmental limitations and the end of our current session.