### PR TITLE
feat: Implement comic rental enhancements for members and admins

### DIFF
--- a/ComicRentalSystem_14Days/Forms/ComicManagementForm.cs
+++ b/ComicRentalSystem_14Days/Forms/ComicManagementForm.cs
@@ -65,6 +65,27 @@ namespace ComicRentalSystem_14Days.Forms
             dgvComics.Columns.Add(new DataGridViewTextBoxColumn { DataPropertyName = "Genre", HeaderText = "類型", Width = 100 });
             dgvComics.Columns.Add(new DataGridViewCheckBoxColumn { DataPropertyName = "IsRented", HeaderText = "已租借", Width = 70 });
             dgvComics.Columns.Add(new DataGridViewTextBoxColumn { DataPropertyName = "RentedToMemberId", HeaderText = "租借會員ID", Width = 100 });
+
+            // Add RentalDate column
+            var rentalDateColumn = new DataGridViewTextBoxColumn
+            {
+                DataPropertyName = nameof(Comic.RentalDate), // "RentalDate"
+                HeaderText = "租借日期",
+                Width = 110 // Or another appropriate width
+            };
+            rentalDateColumn.DefaultCellStyle.Format = "yyyy-MM-dd";
+            dgvComics.Columns.Add(rentalDateColumn);
+
+            // Add ReturnDate column
+            var returnDateColumn = new DataGridViewTextBoxColumn
+            {
+                DataPropertyName = nameof(Comic.ReturnDate), // "ReturnDate"
+                HeaderText = "歸還期限",
+                Width = 110 // Or another appropriate width
+            };
+            returnDateColumn.DefaultCellStyle.Format = "yyyy-MM-dd";
+            dgvComics.Columns.Add(returnDateColumn);
+
             dgvComics.Columns.Add(new DataGridViewTextBoxColumn { DataPropertyName = "Isbn", HeaderText = "ISBN", Width = 120 });
 
             dgvComics.SelectionMode = DataGridViewSelectionMode.FullRowSelect;

--- a/ComicRentalSystem_14Days/Forms/RentalForm.cs
+++ b/ComicRentalSystem_14Days/Forms/RentalForm.cs
@@ -239,6 +239,28 @@ namespace ComicRentalSystem_14Days.Forms
                 AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
             });
 
+            // Add RentalDate column
+            var rentalDateColumn = new DataGridViewTextBoxColumn
+            {
+                DataPropertyName = nameof(Comic.RentalDate),
+                HeaderText = "租借日期",
+                Name = "colRentalDate",
+                Width = 120 // Or another appropriate width
+            };
+            rentalDateColumn.DefaultCellStyle.Format = "yyyy-MM-dd";
+            dgvRentedComics.Columns.Add(rentalDateColumn);
+
+            // Add ReturnDate column
+            var returnDateColumn = new DataGridViewTextBoxColumn
+            {
+                DataPropertyName = nameof(Comic.ReturnDate),
+                HeaderText = "歸還期限",
+                Name = "colReturnDate",
+                Width = 120 // Or another appropriate width
+            };
+            returnDateColumn.DefaultCellStyle.Format = "yyyy-MM-dd";
+            dgvRentedComics.Columns.Add(returnDateColumn);
+
             dgvRentedComics.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
             dgvRentedComics.MultiSelect = false;
             dgvRentedComics.ReadOnly = true;

--- a/ComicRentalSystem_14Days/Forms/RentalPeriodForm.Designer.cs
+++ b/ComicRentalSystem_14Days/Forms/RentalPeriodForm.Designer.cs
@@ -1,0 +1,99 @@
+namespace ComicRentalSystem_14Days.Forms
+{
+    partial class RentalPeriodForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.monthCalendarRental = new System.Windows.Forms.MonthCalendar();
+            this.btnConfirmRental = new System.Windows.Forms.Button();
+            this.btnCancelRental = new System.Windows.Forms.Button();
+            this.lblInfo = new System.Windows.Forms.Label();
+            this.SuspendLayout();
+            //
+            // monthCalendarRental
+            //
+            this.monthCalendarRental.Location = new System.Drawing.Point(18, 50);
+            this.monthCalendarRental.MaxSelectionCount = 1; // Important for selecting a single date
+            this.monthCalendarRental.Name = "monthCalendarRental";
+            this.monthCalendarRental.TabIndex = 0;
+            //
+            // btnConfirmRental
+            //
+            this.btnConfirmRental.Location = new System.Drawing.Point(18, 225);
+            this.btnConfirmRental.Name = "btnConfirmRental";
+            this.btnConfirmRental.Size = new System.Drawing.Size(100, 30);
+            this.btnConfirmRental.TabIndex = 1;
+            this.btnConfirmRental.Text = "Confirm";
+            this.btnConfirmRental.UseVisualStyleBackColor = true;
+            this.btnConfirmRental.Click += new System.EventHandler(this.btnConfirmRental_Click);
+            //
+            // btnCancelRental
+            //
+            this.btnCancelRental.Location = new System.Drawing.Point(145, 225);
+            this.btnCancelRental.Name = "btnCancelRental";
+            this.btnCancelRental.Size = new System.Drawing.Size(100, 30);
+            this.btnCancelRental.TabIndex = 2;
+            this.btnCancelRental.Text = "Cancel";
+            this.btnCancelRental.UseVisualStyleBackColor = true;
+            this.btnCancelRental.Click += new System.EventHandler(this.btnCancelRental_Click);
+            //
+            // lblInfo
+            //
+            this.lblInfo.AutoSize = true;
+            this.lblInfo.Location = new System.Drawing.Point(18, 15);
+            this.lblInfo.Name = "lblInfo";
+            this.lblInfo.Size = new System.Drawing.Size(220, 15);
+            this.lblInfo.TabIndex = 3;
+            this.lblInfo.Text = "Select a return date (Min 3 days, Max 1 month).";
+            //
+            // RentalPeriodForm
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(264, 271);
+            this.Controls.Add(this.lblInfo);
+            this.Controls.Add(this.btnCancelRental);
+            this.Controls.Add(this.btnConfirmRental);
+            this.Controls.Add(this.monthCalendarRental);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "RentalPeriodForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Select Rental Period";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        #endregion
+
+        private System.Windows.Forms.MonthCalendar monthCalendarRental;
+        private System.Windows.Forms.Button btnConfirmRental;
+        private System.Windows.Forms.Button btnCancelRental;
+        private System.Windows.Forms.Label lblInfo;
+    }
+}

--- a/ComicRentalSystem_14Days/Forms/RentalPeriodForm.cs
+++ b/ComicRentalSystem_14Days/Forms/RentalPeriodForm.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Windows.Forms;
+
+namespace ComicRentalSystem_14Days.Forms
+{
+    public partial class RentalPeriodForm : Form
+    {
+        public DateTime SelectedReturnDate { get; private set; }
+
+        public RentalPeriodForm(DateTime minDate, DateTime maxDate)
+        {
+            InitializeComponent();
+
+            monthCalendarRental.MinDate = minDate;
+            monthCalendarRental.MaxDate = maxDate;
+
+            // Attempt to set the initial selected date to minDate, if it's within the valid range.
+            // This also handles the case where minDate might be later than monthCalendarRental.TodayDate if not clamped.
+            if (minDate > monthCalendarRental.TodayDate && minDate <= maxDate)
+            {
+                monthCalendarRental.SelectionStart = minDate;
+            }
+            else if (monthCalendarRental.TodayDate >= minDate && monthCalendarRental.TodayDate <= maxDate)
+            {
+                 monthCalendarRental.SelectionStart = monthCalendarRental.TodayDate;
+            }
+            else
+            {
+                // Fallback if TodayDate is also out of range, though MinDate should be the primary guide.
+                monthCalendarRental.SelectionStart = minDate;
+            }
+            // Ensure the calendar shows the initial selection.
+             monthCalendarRental.SetDate(monthCalendarRental.SelectionStart);
+
+
+            lblInfo.Text = $"Select a return date.\nMin: {minDate:yyyy-MM-dd}\nMax: {maxDate:yyyy-MM-dd}";
+        }
+
+        private void btnConfirmRental_Click(object sender, EventArgs e)
+        {
+            // Ensure a date is selected and it's within the calendar's effective min/max range
+            // (which should be enforced by MonthCalendar itself).
+            if (monthCalendarRental.SelectionStart >= monthCalendarRental.MinDate &&
+                monthCalendarRental.SelectionStart <= monthCalendarRental.MaxDate)
+            {
+                this.SelectedReturnDate = monthCalendarRental.SelectionStart;
+                this.DialogResult = DialogResult.OK;
+                this.Close();
+            }
+            else
+            {
+                // This case should ideally not be hit if MinDate and MaxDate are set correctly.
+                MessageBox.Show("Please select a valid date within the allowed range.", "Invalid Date", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+        }
+
+        private void btnCancelRental_Click(object sender, EventArgs e)
+        {
+            this.DialogResult = DialogResult.Cancel;
+            this.Close();
+        }
+    }
+}

--- a/ComicRentalSystem_14Days/MainForm.Designer.cs
+++ b/ComicRentalSystem_14Days/MainForm.Designer.cs
@@ -148,14 +148,15 @@ namespace ComicRentalSystem_14Days
             dgvAvailableComics.AllowUserToAddRows = false;
             dgvAvailableComics.AllowUserToDeleteRows = false;
             dgvAvailableComics.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            dgvAvailableComics.Dock = DockStyle.Fill;
-            // Adjusted Location and Size to accommodate statusStrip1
+            // dgvAvailableComics.Dock = DockStyle.Fill; // Changed to allow button placement
+            // Adjusted Location and Size to accommodate statusStrip1 and btnRentComic
             dgvAvailableComics.Location = new Point(0, 86);
             dgvAvailableComics.Margin = new Padding(4);
             dgvAvailableComics.Name = "dgvAvailableComics";
             dgvAvailableComics.ReadOnly = true;
             dgvAvailableComics.RowHeadersWidth = 51;
-            dgvAvailableComics.Size = new Size(900, 395); // Height reduced by 22 (statusStrip height)
+            // Size will be adjusted below, or use Anchor properties for responsiveness
+            dgvAvailableComics.Size = new Size(900, 355); // Reduced height to make space for button
             dgvAvailableComics.TabIndex = 2;
             // 
             // lblAvailableComics
@@ -187,11 +188,51 @@ namespace ComicRentalSystem_14Days
             this.toolStripStatusLabelUser.Size = new System.Drawing.Size(136, 17); // Example size, text might make it wider
             this.toolStripStatusLabelUser.Text = "User: None | Role: None";
             //
+            // btnRentComic
+            //
+            this.btnRentComic.Location = new System.Drawing.Point(12, 445);
+            this.btnRentComic.Name = "btnRentComic";
+            this.btnRentComic.Size = new System.Drawing.Size(120, 30);
+            this.btnRentComic.TabIndex = 5;
+            this.btnRentComic.Text = "租借";
+            this.btnRentComic.UseVisualStyleBackColor = true;
+            this.btnRentComic.Visible = false;
+            this.btnRentComic.Enabled = false;
+            this.btnRentComic.Click += new System.EventHandler(this.btnRentComic_Click);
+            //
+            // lblMyRentedComicsHeader
+            //
+            this.lblMyRentedComicsHeader.AutoSize = true;
+            this.lblMyRentedComicsHeader.Font = new System.Drawing.Font("Microsoft JhengHei UI", 10F, System.Drawing.FontStyle.Bold);
+            this.lblMyRentedComicsHeader.Location = new System.Drawing.Point(12, 485); // Positioned below btnRentComic
+            this.lblMyRentedComicsHeader.Name = "lblMyRentedComicsHeader";
+            this.lblMyRentedComicsHeader.Size = new System.Drawing.Size(123, 22);
+            this.lblMyRentedComicsHeader.TabIndex = 6;
+            this.lblMyRentedComicsHeader.Text = "我租借的漫畫";
+            this.lblMyRentedComicsHeader.Visible = false;
+            //
+            // dgvMyRentedComics
+            //
+            this.dgvMyRentedComics.AllowUserToAddRows = false;
+            this.dgvMyRentedComics.AllowUserToDeleteRows = false;
+            this.dgvMyRentedComics.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dgvMyRentedComics.Location = new System.Drawing.Point(12, 510); // Positioned below lblMyRentedComicsHeader
+            this.dgvMyRentedComics.Name = "dgvMyRentedComics";
+            this.dgvMyRentedComics.ReadOnly = true;
+            this.dgvMyRentedComics.RowHeadersWidth = 51;
+            this.dgvMyRentedComics.RowTemplate.Height = 27; // Standard height
+            this.dgvMyRentedComics.Size = new System.Drawing.Size(876, 150); // Takes most of the width, 150px height
+            this.dgvMyRentedComics.TabIndex = 7;
+            this.dgvMyRentedComics.Visible = false;
+            //
             // MainForm
             // 
             AutoScaleDimensions = new SizeF(9F, 19F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(900, 503); // Original ClientSize
+            ClientSize = new Size(900, 690); // Increased client height to accommodate new controls + status bar
+            Controls.Add(this.lblMyRentedComicsHeader); // Added
+            Controls.Add(this.dgvMyRentedComics); // Added
+            Controls.Add(this.btnRentComic);
             Controls.Add(dgvAvailableComics);
             Controls.Add(lblAvailableComics);
             Controls.Add(menuStrip1); // This menuStrip1 seems to be secondary or unused for items
@@ -205,8 +246,9 @@ namespace ComicRentalSystem_14Days
             menuStrip2.ResumeLayout(false);
             menuStrip2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)dgvAvailableComics).EndInit();
-            this.statusStrip1.ResumeLayout(false); // Added
-            this.statusStrip1.PerformLayout(); // Added
+            this.statusStrip1.ResumeLayout(false);
+            this.statusStrip1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.dgvMyRentedComics)).EndInit(); // Added
             ResumeLayout(false);
             PerformLayout();
         }
@@ -229,5 +271,8 @@ namespace ComicRentalSystem_14Days
         private System.Windows.Forms.ToolStripMenuItem logoutToolStripMenuItem;
         private System.Windows.Forms.StatusStrip statusStrip1;
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelUser;
+        private System.Windows.Forms.Button btnRentComic;
+        private System.Windows.Forms.Label lblMyRentedComicsHeader; // Added
+        private System.Windows.Forms.DataGridView dgvMyRentedComics; // Added
     }
 }

--- a/ComicRentalSystem_14Days/Services/MemberService.cs
+++ b/ComicRentalSystem_14Days/Services/MemberService.cs
@@ -226,5 +226,40 @@ namespace ComicRentalSystem_14Days.Services
             }
             return member;
         }
+
+        public Member? GetMemberByUsername(string username)
+        {
+            if (string.IsNullOrWhiteSpace(username))
+            {
+                _logger.LogWarning("GetMemberByUsername called with null or empty username.");
+                return null;
+            }
+
+            // GetAllMembers() ensures the _members list is loaded and returns a copy.
+            var allMembers = GetAllMembers();
+
+            if (allMembers == null || !allMembers.Any())
+            {
+                _logger.LogWarning("GetMemberByUsername: No members available to search.");
+                return null;
+            }
+
+            // Assuming Member.Name is the field that corresponds to the username.
+            // Using OrdinalIgnoreCase for case-insensitive matching, which is common for usernames.
+            Member? foundMember = allMembers.FirstOrDefault(m =>
+                string.Equals(m.Name, username, StringComparison.OrdinalIgnoreCase)
+            );
+
+            if (foundMember != null)
+            {
+                _logger.Log($"GetMemberByUsername: Found member with ID {foundMember.Id} for username '{username}'.");
+            }
+            else
+            {
+                _logger.Log($"GetMemberByUsername: No member found for username '{username}'.");
+            }
+
+            return foundMember;
+        }
     }
 }


### PR DESCRIPTION
This commit introduces several new features and improvements to the comic rental system:

1.  **Updated Comic Model (`Comic.cs`):**
    *   Added `RentalDate` (nullable DateTime) and `ReturnDate` (nullable DateTime) properties to track comic rental periods.
    *   Modified `ToCsvString()` and `FromCsvString()` methods to serialize/deserialize these new date fields.
    *   Ensured backward compatibility: `FromCsvString()` can now handle older CSV files lacking the new date fields by defaulting them to null.

2.  **Enhanced MainForm for Regular Members (`MainForm.cs`):**
    *   **UI Access Control:** "管理" (Management) and "工具" (Tools) dropdown menus are now hidden for users logged in with the "Member" role.
    *   **Rental Button:** A "租借" (Rent) button was added, visible only to members. This button is enabled when an available comic is selected.
    *   **Rental Process:**
        *   Implemented the click event for the "Rent" button.
        *   Created a new `RentalPeriodForm` that allows members to select a rental duration (minimum 3 days, maximum 1 month from the current date) using a `MonthCalendar` control.
        *   Upon confirming the rental period, the selected comic's status is updated: `IsRented` set to true, `RentedToMemberId` set to the current member's ID, and `RentalDate` and `ReturnDate` are recorded.
        *   Changes are saved via `ComicService.UpdateComic()`.
        *   A confirmation message displaying the return deadline is shown to the member.
    *   **"My Rented Comics" View:**
        *   Added a new DataGridView (`dgvMyRentedComics`) and a header label to `MainForm`. These are visible only to logged-in members.
        *   Implemented `LoadMyRentedComics()` to fetch and display comics currently rented by the member, including columns for "Title", "Author", "RentalDate", and "ReturnDate".
        *   This view is updated on form load, after a member rents a comic, and when underlying comic data changes.

3.  **Member Identification (`MemberService.cs`):**
    *   Added a public method `GetMemberByUsername(string username)` to `MemberService.cs`.
    *   This method retrieves a `Member` object based on the provided username (assuming `Member.Name` corresponds to the username, case-insensitive).
    *   This is crucial for linking the logged-in `User` to their `Member` record for rental operations. Includes logging and error handling.

4.  **Enhanced Admin Views:**
    *   **`ComicManagementForm.cs`:** Modified the main comics DataGridView (`dgvComics`) to include new columns for "租借日期" (RentalDate) and "歸還期限" (ReturnDate), allowing admins to see these details for all comics.
    *   **`RentalForm.cs`:** Modified the `dgvRentedComics` (which shows comics rented by a specific member) to also include "租借日期" (RentalDate) and "歸還期限" (ReturnDate) columns for consistency.

These changes address your requirements by providing role-specific UI and functionality for comic rentals, including rental period selection, return date visibility for members, and enhanced rental information display for administrators.