### PR TITLE
Debug: Temporarily comment out more controls for MainForm crash

### DIFF
--- a/ComicRentalSystem_14Days/MainForm.Designer.cs
+++ b/ComicRentalSystem_14Days/MainForm.Designer.cs
@@ -73,6 +73,12 @@ namespace ComicRentalSystem_14Days
             menuStrip2.TabIndex = 1;
             menuStrip2.Text = "menuStrip2";
             // 
+            // this.btnRentComic = new System.Windows.Forms.Button();
+            //
+            // this.lblMyRentedComicsHeader = new System.Windows.Forms.Label();
+            // this.dgvMyRentedComics = new System.Windows.Forms.DataGridView();
+            // ((System.ComponentModel.ISupportInitialize)(this.dgvMyRentedComics)).BeginInit();
+            //
             // 檔案ToolStripMenuItem
             // 
             檔案ToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { 離開ToolStripMenuItem });
@@ -190,49 +196,49 @@ namespace ComicRentalSystem_14Days
             //
             // btnRentComic
             //
-            this.btnRentComic.Location = new System.Drawing.Point(12, 445);
-            this.btnRentComic.Name = "btnRentComic";
-            this.btnRentComic.Size = new System.Drawing.Size(120, 30);
-            this.btnRentComic.TabIndex = 5;
-            this.btnRentComic.Text = "租借";
-            this.btnRentComic.UseVisualStyleBackColor = true;
-            this.btnRentComic.Visible = false;
-            this.btnRentComic.Enabled = false;
-            this.btnRentComic.Click += new System.EventHandler(this.btnRentComic_Click);
+            // this.btnRentComic.Location = new System.Drawing.Point(12, 445);
+            // this.btnRentComic.Name = "btnRentComic";
+            // this.btnRentComic.Size = new System.Drawing.Size(120, 30);
+            // this.btnRentComic.TabIndex = 5;
+            // this.btnRentComic.Text = "租借";
+            // this.btnRentComic.UseVisualStyleBackColor = true;
+            // this.btnRentComic.Visible = false;
+            // this.btnRentComic.Enabled = false;
+            // this.btnRentComic.Click += new System.EventHandler(this.btnRentComic_Click);
             //
             // lblMyRentedComicsHeader
             //
-            this.lblMyRentedComicsHeader.AutoSize = true;
-            this.lblMyRentedComicsHeader.Font = new System.Drawing.Font("Microsoft JhengHei UI", 10F, System.Drawing.FontStyle.Bold);
-            this.lblMyRentedComicsHeader.Location = new System.Drawing.Point(12, 485); // Positioned below btnRentComic
-            this.lblMyRentedComicsHeader.Name = "lblMyRentedComicsHeader";
-            this.lblMyRentedComicsHeader.Size = new System.Drawing.Size(123, 22);
-            this.lblMyRentedComicsHeader.TabIndex = 6;
-            this.lblMyRentedComicsHeader.Text = "我租借的漫畫";
-            this.lblMyRentedComicsHeader.Visible = false;
+            // this.lblMyRentedComicsHeader.AutoSize = true;
+            // this.lblMyRentedComicsHeader.Font = new System.Drawing.Font("Microsoft JhengHei UI", 10F, System.Drawing.FontStyle.Bold);
+            // this.lblMyRentedComicsHeader.Location = new System.Drawing.Point(12, 485); // Positioned below btnRentComic
+            // this.lblMyRentedComicsHeader.Name = "lblMyRentedComicsHeader";
+            // this.lblMyRentedComicsHeader.Size = new System.Drawing.Size(123, 22);
+            // this.lblMyRentedComicsHeader.TabIndex = 6;
+            // this.lblMyRentedComicsHeader.Text = "我租借的漫畫";
+            // this.lblMyRentedComicsHeader.Visible = false;
             //
             // dgvMyRentedComics
             //
-            this.dgvMyRentedComics.AllowUserToAddRows = false;
-            this.dgvMyRentedComics.AllowUserToDeleteRows = false;
-            this.dgvMyRentedComics.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dgvMyRentedComics.Location = new System.Drawing.Point(12, 510); // Positioned below lblMyRentedComicsHeader
-            this.dgvMyRentedComics.Name = "dgvMyRentedComics";
-            this.dgvMyRentedComics.ReadOnly = true;
-            this.dgvMyRentedComics.RowHeadersWidth = 51;
-            this.dgvMyRentedComics.RowTemplate.Height = 27; // Standard height
-            this.dgvMyRentedComics.Size = new System.Drawing.Size(876, 150); // Takes most of the width, 150px height
-            this.dgvMyRentedComics.TabIndex = 7;
-            this.dgvMyRentedComics.Visible = false;
+            // this.dgvMyRentedComics.AllowUserToAddRows = false;
+            // this.dgvMyRentedComics.AllowUserToDeleteRows = false;
+            // this.dgvMyRentedComics.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            // this.dgvMyRentedComics.Location = new System.Drawing.Point(12, 510); // Positioned below lblMyRentedComicsHeader
+            // this.dgvMyRentedComics.Name = "dgvMyRentedComics";
+            // this.dgvMyRentedComics.ReadOnly = true;
+            // this.dgvMyRentedComics.RowHeadersWidth = 51;
+            // this.dgvMyRentedComics.RowTemplate.Height = 27; // Standard height
+            // this.dgvMyRentedComics.Size = new System.Drawing.Size(876, 150); // Takes most of the width, 150px height
+            // this.dgvMyRentedComics.TabIndex = 7;
+            // this.dgvMyRentedComics.Visible = false;
             //
             // MainForm
             // 
             AutoScaleDimensions = new SizeF(9F, 19F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(900, 690); // Increased client height to accommodate new controls + status bar
-            Controls.Add(this.lblMyRentedComicsHeader); // Added
-            Controls.Add(this.dgvMyRentedComics); // Added
-            Controls.Add(this.btnRentComic);
+            // Controls.Add(this.lblMyRentedComicsHeader); // Added
+            // Controls.Add(this.dgvMyRentedComics); // Added
+            // Controls.Add(this.btnRentComic);
             Controls.Add(dgvAvailableComics);
             Controls.Add(lblAvailableComics);
             Controls.Add(menuStrip1); // This menuStrip1 seems to be secondary or unused for items
@@ -248,7 +254,7 @@ namespace ComicRentalSystem_14Days
             ((System.ComponentModel.ISupportInitialize)dgvAvailableComics).EndInit();
             this.statusStrip1.ResumeLayout(false);
             this.statusStrip1.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dgvMyRentedComics)).EndInit(); // Added
+            // ((System.ComponentModel.ISupportInitialize)(this.dgvMyRentedComics)).EndInit(); // Added
             ResumeLayout(false);
             PerformLayout();
         }
@@ -271,8 +277,8 @@ namespace ComicRentalSystem_14Days
         private System.Windows.Forms.ToolStripMenuItem logoutToolStripMenuItem;
         private System.Windows.Forms.StatusStrip statusStrip1;
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelUser;
-        private System.Windows.Forms.Button btnRentComic;
-        private System.Windows.Forms.Label lblMyRentedComicsHeader; // Added
-        private System.Windows.Forms.DataGridView dgvMyRentedComics; // Added
+        // private System.Windows.Forms.Button btnRentComic;
+        // private System.Windows.Forms.Label lblMyRentedComicsHeader; // Added
+        // private System.Windows.Forms.DataGridView dgvMyRentedComics; // Added
     }
 }

--- a/ComicRentalSystem_14Days/MainForm.cs
+++ b/ComicRentalSystem_14Days/MainForm.cs
@@ -37,18 +37,22 @@ namespace ComicRentalSystem_14Days
             }
         }
         // Primary constructor
-        public MainForm(ILogger logger, ComicService comicService, MemberService memberService, IReloadService reloadService, User currentUser) : this()
+        public MainForm(ILogger logger, ComicService comicService, MemberService memberService, IReloadService reloadService, User currentUser)
+            : base() // Explicitly call BaseForm's parameterless constructor
         {
+            // Initialize fields FIRST
             this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this._comicService = comicService ?? throw new ArgumentNullException(nameof(comicService));
             this._memberService = memberService ?? throw new ArgumentNullException(nameof(memberService));
             this._reloadService = reloadService ?? throw new ArgumentNullException(nameof(reloadService));
             this._currentUser = currentUser ?? throw new ArgumentNullException(nameof(currentUser));
 
-            base.SetLogger(logger); // Assumes BaseForm has public void SetLogger(ILogger logger)
-            
-            _logger.Log($"MainForm initialized for user: {_currentUser.Username}, Role: {_currentUser.Role}");
+            base.SetLogger(logger); // Initialize BaseForm's logger
 
+            InitializeComponent(); // NOW call InitializeComponent
+
+            // These are still needed to apply role-based UI logic
+            _logger.Log($"MainForm initialized for user: {_currentUser.Username}, Role: {_currentUser.Role}");
             SetupUIAccessControls();
             UpdateStatusBar();
         }
@@ -58,10 +62,10 @@ namespace ComicRentalSystem_14Days
             this._logger?.Log("MainForm is loading.");
             // _comicService is guaranteed non-null by constructor, direct use.
             SetupDataGridView(); // Sets up dgvAvailableComics
-            SetupMyRentedComicsDataGridView(); // Sets up dgvMyRentedComics
+            // SetupMyRentedComicsDataGridView(); // Sets up dgvMyRentedComics
 
             LoadAvailableComics(); // Loads data for available comics
-            LoadMyRentedComics();  // Loads data for member's rented comics
+            // LoadMyRentedComics();  // Loads data for member's rented comics
 
             this._comicService.ComicsChanged += ComicService_ComicsChanged;
             dgvAvailableComics.SelectionChanged += dgvAvailableComics_SelectionChanged;
@@ -77,21 +81,21 @@ namespace ComicRentalSystem_14Days
             if (_currentUser == null) return; // Should not happen if form is loaded correctly
 
             bool isMember = _currentUser.Role == UserRole.Member;
-            if (isMember)
-            {
-                btnRentComic.Enabled = dgvAvailableComics.SelectedRows.Count > 0;
-            }
-            else
-            {
-                btnRentComic.Enabled = false;
-            }
+            // if (isMember)
+            // {
+            //     btnRentComic.Enabled = dgvAvailableComics.SelectedRows.Count > 0;
+            // }
+            // else
+            // {
+            //     btnRentComic.Enabled = false;
+            // }
         }
 
         private void ComicService_ComicsChanged(object? sender, EventArgs e)
         {
             this._logger?.Log("ComicsChanged event received, reloading available comics and member's rented comics.");
             LoadAvailableComics();
-            LoadMyRentedComics(); // Also reload member's rented comics
+            // LoadMyRentedComics(); // Also reload member's rented comics
         }
 
         private void SetupDataGridView()
@@ -212,29 +216,32 @@ namespace ComicRentalSystem_14Days
             }
 
             // Setup for btnRentComic and related member-specific UI
-            if (btnRentComic != null && lblMyRentedComicsHeader != null && dgvMyRentedComics != null)
-            {
-                if (!isAdmin) // User is a Member
-                {
-                    btnRentComic.Visible = true;
-                    btnRentComic.Enabled = dgvAvailableComics.SelectedRows.Count > 0;
-                    lblMyRentedComicsHeader.Visible = true;
-                    dgvMyRentedComics.Visible = true;
-                }
-                else // User is an Admin
-                {
-                    btnRentComic.Visible = false;
-                    btnRentComic.Enabled = false;
-                    lblMyRentedComicsHeader.Visible = false;
-                    dgvMyRentedComics.Visible = false;
-                }
-                _logger.Log($"btnRentComic visibility set to {!isAdmin}, enabled state based on selection/role.");
-                _logger.Log($"lblMyRentedComicsHeader and dgvMyRentedComics visibility set to {!isAdmin}.");
-            }
-            else
-            {
-                _logger.LogWarning("One or more UI controls (btnRentComic, lblMyRentedComicsHeader, dgvMyRentedComics) not found during SetupUIAccessControls.");
-            }
+            // Setup for btnRentComic and related member-specific UI
+            // if (btnRentComic != null && lblMyRentedComicsHeader != null && dgvMyRentedComics != null)
+            // if (lblMyRentedComicsHeader != null && dgvMyRentedComics != null)
+            // {
+            //     if (!isAdmin) // User is a Member
+            //     {
+            //         // btnRentComic.Visible = true;
+            //         // btnRentComic.Enabled = dgvAvailableComics.SelectedRows.Count > 0;
+            //         // lblMyRentedComicsHeader.Visible = true;
+            //         // dgvMyRentedComics.Visible = true;
+            //     }
+            //     else // User is an Admin
+            //     {
+            //         // btnRentComic.Visible = false;
+            //         // btnRentComic.Enabled = false;
+            //         // lblMyRentedComicsHeader.Visible = false;
+            //         // dgvMyRentedComics.Visible = false;
+            //     }
+            //     // _logger.Log($"btnRentComic visibility set to {!isAdmin}, enabled state based on selection/role.");
+            //     // _logger.Log($"lblMyRentedComicsHeader and dgvMyRentedComics visibility set to {!isAdmin}.");
+            // }
+            // else
+            // {
+            //     // Updated log message to reflect that btnRentComic is not checked here anymore
+            //     _logger.LogWarning("One or more UI controls (lblMyRentedComicsHeader, dgvMyRentedComics) not found during SetupUIAccessControls.");
+            // }
         }
 
         private void UpdateStatusBar()
@@ -261,108 +268,108 @@ namespace ComicRentalSystem_14Days
             }
         }
 
-        private void SetupMyRentedComicsDataGridView()
-        {
-            _logger?.Log("Setting up DataGridView for member's rented comics (dgvMyRentedComics).");
-            dgvMyRentedComics.AutoGenerateColumns = false;
-            dgvMyRentedComics.Columns.Clear();
-            dgvMyRentedComics.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
+        // private void SetupMyRentedComicsDataGridView()
+        // {
+        //     _logger?.Log("Setting up DataGridView for member's rented comics (dgvMyRentedComics).");
+        //     dgvMyRentedComics.AutoGenerateColumns = false;
+        //     dgvMyRentedComics.Columns.Clear();
+        //     dgvMyRentedComics.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
 
-            dgvMyRentedComics.Columns.Add(new DataGridViewTextBoxColumn { DataPropertyName = "Title", HeaderText = "書名", FillWeight = 35 });
-            dgvMyRentedComics.Columns.Add(new DataGridViewTextBoxColumn { DataPropertyName = "Author", HeaderText = "作者", FillWeight = 25 });
+        //     dgvMyRentedComics.Columns.Add(new DataGridViewTextBoxColumn { DataPropertyName = "Title", HeaderText = "書名", FillWeight = 35 });
+        //     dgvMyRentedComics.Columns.Add(new DataGridViewTextBoxColumn { DataPropertyName = "Author", HeaderText = "作者", FillWeight = 25 });
 
-            var rentalDateColumn = new DataGridViewTextBoxColumn {
-                DataPropertyName = "RentalDate",
-                HeaderText = "租借日期",
-                FillWeight = 20
-            };
-            rentalDateColumn.DefaultCellStyle.Format = "yyyy-MM-dd"; // Format as date only
-            dgvMyRentedComics.Columns.Add(rentalDateColumn);
+        //     var rentalDateColumn = new DataGridViewTextBoxColumn {
+        //         DataPropertyName = "RentalDate",
+        //         HeaderText = "租借日期",
+        //         FillWeight = 20
+        //     };
+        //     rentalDateColumn.DefaultCellStyle.Format = "yyyy-MM-dd"; // Format as date only
+        //     dgvMyRentedComics.Columns.Add(rentalDateColumn);
 
-            var returnDateColumn = new DataGridViewTextBoxColumn {
-                DataPropertyName = "ReturnDate",
-                HeaderText = "歸還日期",
-                FillWeight = 20
-            };
-            returnDateColumn.DefaultCellStyle.Format = "yyyy-MM-dd"; // Format as date only
-            dgvMyRentedComics.Columns.Add(returnDateColumn);
+        //     var returnDateColumn = new DataGridViewTextBoxColumn {
+        //         DataPropertyName = "ReturnDate",
+        //         HeaderText = "歸還日期",
+        //         FillWeight = 20
+        //     };
+        //     returnDateColumn.DefaultCellStyle.Format = "yyyy-MM-dd"; // Format as date only
+        //     dgvMyRentedComics.Columns.Add(returnDateColumn);
 
-            dgvMyRentedComics.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
-            dgvMyRentedComics.MultiSelect = false;
-            dgvMyRentedComics.ReadOnly = true;
-            dgvMyRentedComics.AllowUserToAddRows = false;
-        }
+        //     dgvMyRentedComics.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
+        //     dgvMyRentedComics.MultiSelect = false;
+        //     dgvMyRentedComics.ReadOnly = true;
+        //     dgvMyRentedComics.AllowUserToAddRows = false;
+        // }
 
-        private void LoadMyRentedComics()
-        {
-            if (_currentUser == null || _comicService == null || _memberService == null || _logger == null)
-            {
-                _logger?.LogWarning("LoadMyRentedComics: CurrentUser or critical services are null. Clearing DGV.");
-                if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
-                else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
-                return;
-            }
+        // private void LoadMyRentedComics()
+        // {
+        //     if (_currentUser == null || _comicService == null || _memberService == null || _logger == null)
+        //     {
+        //         _logger?.LogWarning("LoadMyRentedComics: CurrentUser or critical services are null. Clearing DGV.");
+        //         if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
+        //         else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
+        //         return;
+        //     }
 
-            if (_currentUser.Role != UserRole.Member)
-            {
-                _logger?.Log("LoadMyRentedComics: User is not a Member. Clearing DGV.");
-                 if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
-                else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
-                return;
-            }
+        //     if (_currentUser.Role != UserRole.Member)
+        //     {
+        //         _logger?.Log("LoadMyRentedComics: User is not a Member. Clearing DGV.");
+        //          if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
+        //         else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
+        //         return;
+        //     }
 
-            _logger?.Log($"LoadMyRentedComics: Loading comics for member '{_currentUser.Username}'.");
+        //     _logger?.Log($"LoadMyRentedComics: Loading comics for member '{_currentUser.Username}'.");
 
-            try
-            {
-                Member? currentMember = null;
-                try
-                {
-                    currentMember = _memberService.GetMemberByUsername(_currentUser.Username);
-                }
-                catch (NotImplementedException nie)
-                {
-                    _logger?.LogError($"LoadMyRentedComics: _memberService.GetMemberByUsername is not implemented. {nie.Message}");
-                    if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
-                    else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
-                    return;
-                }
+        //     try
+        //     {
+        //         Member? currentMember = null;
+        //         try
+        //         {
+        //             currentMember = _memberService.GetMemberByUsername(_currentUser.Username);
+        //         }
+        //         catch (NotImplementedException nie)
+        //         {
+        //             _logger?.LogError($"LoadMyRentedComics: _memberService.GetMemberByUsername is not implemented. {nie.Message}");
+        //             if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
+        //             else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
+        //             return;
+        //         }
 
-                if (currentMember == null)
-                {
-                    _logger?.LogWarning($"LoadMyRentedComics: Member profile not found for username '{_currentUser.Username}'.");
-                     if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
-                    else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
-                    return;
-                }
-                int currentMemberId = currentMember.Id;
+        //         if (currentMember == null)
+        //         {
+        //             _logger?.LogWarning($"LoadMyRentedComics: Member profile not found for username '{_currentUser.Username}'.");
+        //              if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
+        //             else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
+        //             return;
+        //         }
+        //         int currentMemberId = currentMember.Id;
 
-                var allComics = _comicService.GetAllComics();
-                var myRentedComics = allComics.Where(c => c.IsRented && c.RentedToMemberId == currentMemberId).ToList();
+        //         var allComics = _comicService.GetAllComics();
+        //         var myRentedComics = allComics.Where(c => c.IsRented && c.RentedToMemberId == currentMemberId).ToList();
 
-                Action updateDataSource = () => {
-                    dgvMyRentedComics.DataSource = null;
-                    dgvMyRentedComics.DataSource = myRentedComics;
-                };
+        //         Action updateDataSource = () => {
+        //             dgvMyRentedComics.DataSource = null;
+        //             dgvMyRentedComics.DataSource = myRentedComics;
+        //         };
 
-                if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired)
-                {
-                    this.Invoke(updateDataSource);
-                }
-                else if (dgvMyRentedComics.IsHandleCreated)
-                {
-                    updateDataSource();
-                }
-                _logger?.Log($"LoadMyRentedComics: Successfully loaded {myRentedComics.Count} rented comics for member ID {currentMemberId}.");
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogError("LoadMyRentedComics: Error loading member's rented comics.", ex);
-                MessageBox.Show($"載入您的租借漫畫列表時發生錯誤: {ex.Message}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
-                else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
-            }
-        }
+        //         if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired)
+        //         {
+        //             this.Invoke(updateDataSource);
+        //         }
+        //         else if (dgvMyRentedComics.IsHandleCreated)
+        //         {
+        //             updateDataSource();
+        //         }
+        //         _logger?.Log($"LoadMyRentedComics: Successfully loaded {myRentedComics.Count} rented comics for member ID {currentMemberId}.");
+        //     }
+        //     catch (Exception ex)
+        //     {
+        //         _logger?.LogError("LoadMyRentedComics: Error loading member's rented comics.", ex);
+        //         MessageBox.Show($"載入您的租借漫畫列表時發生錯誤: {ex.Message}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        //         if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
+        //         else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
+        //     }
+        // }
 
         private void 離開ToolStripMenuItem_Click(object sender, EventArgs e)
         {
@@ -527,7 +534,7 @@ namespace ComicRentalSystem_14Days
                         _logger?.Log($"Comic '{selectedComic.Title}' (ID: {selectedComic.Id}) rented to member ID {member.Id} (Username: {_currentUser.Username}) until {selectedReturnDate:yyyy-MM-dd}.");
                         MessageBox.Show($"漫畫 '{selectedComic.Title}' 已成功租借至 {selectedReturnDate:yyyy-MM-dd}。", "租借成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
                         LoadAvailableComics(); // Refresh the list of available comics
-                        LoadMyRentedComics();  // Refresh the list of member's rented comics
+                        // LoadMyRentedComics();  // Refresh the list of member's rented comics
                         dgvAvailableComics_SelectionChanged(null, EventArgs.Empty); // Update button state for btnRentComic
                     }
                     catch (Exception ex)


### PR DESCRIPTION
Building on the previous step (btnRentComic commented out), this change also comments out lblMyRentedComicsHeader and dgvMyRentedComics, and their usages in MainForm.Designer.cs and MainForm.cs.

This is to further isolate a NullReferenceException occurring in MainForm.InitializeComponent.