### PR TITLE
This change reintroduces `dgvMyRentedComics` and its associated metho…

### DIFF
--- a/ComicRentalSystem_14Days/MainForm.Designer.cs
+++ b/ComicRentalSystem_14Days/MainForm.Designer.cs
@@ -73,6 +73,12 @@ namespace ComicRentalSystem_14Days
             menuStrip2.TabIndex = 1;
             menuStrip2.Text = "menuStrip2";
             // 
+            // this.btnRentComic = new System.Windows.Forms.Button();
+            //
+            this.lblMyRentedComicsHeader = new System.Windows.Forms.Label();
+            this.dgvMyRentedComics = new System.Windows.Forms.DataGridView();
+            ((System.ComponentModel.ISupportInitialize)(this.dgvMyRentedComics)).BeginInit();
+            //
             // 檔案ToolStripMenuItem
             // 
             檔案ToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { 離開ToolStripMenuItem });
@@ -190,15 +196,15 @@ namespace ComicRentalSystem_14Days
             //
             // btnRentComic
             //
-            this.btnRentComic.Location = new System.Drawing.Point(12, 445);
-            this.btnRentComic.Name = "btnRentComic";
-            this.btnRentComic.Size = new System.Drawing.Size(120, 30);
-            this.btnRentComic.TabIndex = 5;
-            this.btnRentComic.Text = "租借";
-            this.btnRentComic.UseVisualStyleBackColor = true;
-            this.btnRentComic.Visible = false;
-            this.btnRentComic.Enabled = false;
-            this.btnRentComic.Click += new System.EventHandler(this.btnRentComic_Click);
+            // this.btnRentComic.Location = new System.Drawing.Point(12, 445);
+            // this.btnRentComic.Name = "btnRentComic";
+            // this.btnRentComic.Size = new System.Drawing.Size(120, 30);
+            // this.btnRentComic.TabIndex = 5;
+            // this.btnRentComic.Text = "租借";
+            // this.btnRentComic.UseVisualStyleBackColor = true;
+            // this.btnRentComic.Visible = false;
+            // this.btnRentComic.Enabled = false;
+            // this.btnRentComic.Click += new System.EventHandler(this.btnRentComic_Click);
             //
             // lblMyRentedComicsHeader
             //
@@ -232,7 +238,7 @@ namespace ComicRentalSystem_14Days
             ClientSize = new Size(900, 690); // Increased client height to accommodate new controls + status bar
             Controls.Add(this.lblMyRentedComicsHeader); // Added
             Controls.Add(this.dgvMyRentedComics); // Added
-            Controls.Add(this.btnRentComic);
+            // Controls.Add(this.btnRentComic);
             Controls.Add(dgvAvailableComics);
             Controls.Add(lblAvailableComics);
             Controls.Add(menuStrip1); // This menuStrip1 seems to be secondary or unused for items
@@ -271,7 +277,7 @@ namespace ComicRentalSystem_14Days
         private System.Windows.Forms.ToolStripMenuItem logoutToolStripMenuItem;
         private System.Windows.Forms.StatusStrip statusStrip1;
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelUser;
-        private System.Windows.Forms.Button btnRentComic;
+        // private System.Windows.Forms.Button btnRentComic;
         private System.Windows.Forms.Label lblMyRentedComicsHeader; // Added
         private System.Windows.Forms.DataGridView dgvMyRentedComics; // Added
     }

--- a/ComicRentalSystem_14Days/MainForm.cs
+++ b/ComicRentalSystem_14Days/MainForm.cs
@@ -37,18 +37,22 @@ namespace ComicRentalSystem_14Days
             }
         }
         // Primary constructor
-        public MainForm(ILogger logger, ComicService comicService, MemberService memberService, IReloadService reloadService, User currentUser) : this()
+        public MainForm(ILogger logger, ComicService comicService, MemberService memberService, IReloadService reloadService, User currentUser)
+            : base() // Explicitly call BaseForm's parameterless constructor
         {
+            // Initialize fields FIRST
             this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this._comicService = comicService ?? throw new ArgumentNullException(nameof(comicService));
             this._memberService = memberService ?? throw new ArgumentNullException(nameof(memberService));
             this._reloadService = reloadService ?? throw new ArgumentNullException(nameof(reloadService));
             this._currentUser = currentUser ?? throw new ArgumentNullException(nameof(currentUser));
 
-            base.SetLogger(logger); // Assumes BaseForm has public void SetLogger(ILogger logger)
-            
-            _logger.Log($"MainForm initialized for user: {_currentUser.Username}, Role: {_currentUser.Role}");
+            base.SetLogger(logger); // Initialize BaseForm's logger
 
+            InitializeComponent(); // NOW call InitializeComponent
+
+            // These are still needed to apply role-based UI logic
+            _logger.Log($"MainForm initialized for user: {_currentUser.Username}, Role: {_currentUser.Role}");
             SetupUIAccessControls();
             UpdateStatusBar();
         }
@@ -77,14 +81,14 @@ namespace ComicRentalSystem_14Days
             if (_currentUser == null) return; // Should not happen if form is loaded correctly
 
             bool isMember = _currentUser.Role == UserRole.Member;
-            if (isMember)
-            {
-                btnRentComic.Enabled = dgvAvailableComics.SelectedRows.Count > 0;
-            }
-            else
-            {
-                btnRentComic.Enabled = false;
-            }
+            // if (isMember)
+            // {
+            //     btnRentComic.Enabled = dgvAvailableComics.SelectedRows.Count > 0;
+            // }
+            // else
+            // {
+            //     btnRentComic.Enabled = false;
+            // }
         }
 
         private void ComicService_ComicsChanged(object? sender, EventArgs e)
@@ -212,28 +216,27 @@ namespace ComicRentalSystem_14Days
             }
 
             // Setup for btnRentComic and related member-specific UI
-            if (btnRentComic != null && lblMyRentedComicsHeader != null && dgvMyRentedComics != null)
+            if (lblMyRentedComicsHeader != null && dgvMyRentedComics != null)
             {
                 if (!isAdmin) // User is a Member
                 {
-                    btnRentComic.Visible = true;
-                    btnRentComic.Enabled = dgvAvailableComics.SelectedRows.Count > 0;
                     lblMyRentedComicsHeader.Visible = true;
                     dgvMyRentedComics.Visible = true;
+                    // btnRentComic.Visible = true; (remains commented)
+                    // btnRentComic.Enabled = dgvAvailableComics.SelectedRows.Count > 0; (remains commented)
                 }
                 else // User is an Admin
                 {
-                    btnRentComic.Visible = false;
-                    btnRentComic.Enabled = false;
                     lblMyRentedComicsHeader.Visible = false;
                     dgvMyRentedComics.Visible = false;
+                    // btnRentComic.Visible = false; (remains commented)
+                    // btnRentComic.Enabled = false; (remains commented)
                 }
-                _logger.Log($"btnRentComic visibility set to {!isAdmin}, enabled state based on selection/role.");
-                _logger.Log($"lblMyRentedComicsHeader and dgvMyRentedComics visibility set to {!isAdmin}.");
+                _logger.Log($"lblMyRentedComicsHeader and dgvMyRentedComics visibility set based on admin status.");
             }
             else
             {
-                _logger.LogWarning("One or more UI controls (btnRentComic, lblMyRentedComicsHeader, dgvMyRentedComics) not found during SetupUIAccessControls.");
+                _logger.LogWarning("Some member-specific UI controls (lblMyRentedComicsHeader or dgvMyRentedComics) not found during SetupUIAccessControls.");
             }
         }
 


### PR DESCRIPTION
…ds (`SetupMyRentedComicsDataGridView`, `LoadMyRentedComics`) and UI logic in `MainForm.Designer.cs` and `MainForm.cs`.

`lblMyRentedComicsHeader` is already restored.
`btnRentComic` remains commented out.

This is to test if restoring `dgvMyRentedComics`, in addition to `lblMyRentedComicsHeader`, keeps the application stable.