### PR TITLE
Fix: Resolve CS0103 and CS1061 errors for dgvMyRentedComics

### DIFF
--- a/ComicRentalSystem_14Days/MainForm.Designer.cs
+++ b/ComicRentalSystem_14Days/MainForm.Designer.cs
@@ -208,28 +208,28 @@ namespace ComicRentalSystem_14Days
             //
             // lblMyRentedComicsHeader
             //
-            // this.lblMyRentedComicsHeader.AutoSize = true;
-            // this.lblMyRentedComicsHeader.Font = new System.Drawing.Font("Microsoft JhengHei UI", 10F, System.Drawing.FontStyle.Bold);
-            // this.lblMyRentedComicsHeader.Location = new System.Drawing.Point(12, 485); // Positioned below btnRentComic
-            // this.lblMyRentedComicsHeader.Name = "lblMyRentedComicsHeader";
-            // this.lblMyRentedComicsHeader.Size = new System.Drawing.Size(123, 22);
-            // this.lblMyRentedComicsHeader.TabIndex = 6;
-            // this.lblMyRentedComicsHeader.Text = "我租借的漫畫";
-            // this.lblMyRentedComicsHeader.Visible = false;
+            this.lblMyRentedComicsHeader.AutoSize = true;
+            this.lblMyRentedComicsHeader.Font = new System.Drawing.Font("Microsoft JhengHei UI", 10F, System.Drawing.FontStyle.Bold);
+            this.lblMyRentedComicsHeader.Location = new System.Drawing.Point(12, 485); // Positioned below btnRentComic
+            this.lblMyRentedComicsHeader.Name = "lblMyRentedComicsHeader";
+            this.lblMyRentedComicsHeader.Size = new System.Drawing.Size(123, 22);
+            this.lblMyRentedComicsHeader.TabIndex = 6;
+            this.lblMyRentedComicsHeader.Text = "我租借的漫畫";
+            this.lblMyRentedComicsHeader.Visible = false;
             //
             // dgvMyRentedComics
             //
-            // this.dgvMyRentedComics.AllowUserToAddRows = false;
-            // this.dgvMyRentedComics.AllowUserToDeleteRows = false;
-            // this.dgvMyRentedComics.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            // this.dgvMyRentedComics.Location = new System.Drawing.Point(12, 510); // Positioned below lblMyRentedComicsHeader
-            // this.dgvMyRentedComics.Name = "dgvMyRentedComics";
-            // this.dgvMyRentedComics.ReadOnly = true;
-            // this.dgvMyRentedComics.RowHeadersWidth = 51;
-            // this.dgvMyRentedComics.RowTemplate.Height = 27; // Standard height
-            // this.dgvMyRentedComics.Size = new System.Drawing.Size(876, 150); // Takes most of the width, 150px height
-            // this.dgvMyRentedComics.TabIndex = 7;
-            // this.dgvMyRentedComics.Visible = false;
+            this.dgvMyRentedComics.AllowUserToAddRows = false;
+            this.dgvMyRentedComics.AllowUserToDeleteRows = false;
+            this.dgvMyRentedComics.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dgvMyRentedComics.Location = new System.Drawing.Point(12, 510); // Positioned below lblMyRentedComicsHeader
+            this.dgvMyRentedComics.Name = "dgvMyRentedComics";
+            this.dgvMyRentedComics.ReadOnly = true;
+            this.dgvMyRentedComics.RowHeadersWidth = 51;
+            this.dgvMyRentedComics.RowTemplate.Height = 27; // Standard height
+            this.dgvMyRentedComics.Size = new System.Drawing.Size(876, 150); // Takes most of the width, 150px height
+            this.dgvMyRentedComics.TabIndex = 7;
+            this.dgvMyRentedComics.Visible = false;
             //
             // MainForm
             // 
@@ -254,7 +254,7 @@ namespace ComicRentalSystem_14Days
             ((System.ComponentModel.ISupportInitialize)dgvAvailableComics).EndInit();
             this.statusStrip1.ResumeLayout(false);
             this.statusStrip1.PerformLayout();
-            // ((System.ComponentModel.ISupportInitialize)(this.dgvMyRentedComics)).EndInit(); // Added
+            ((System.ComponentModel.ISupportInitialize)(this.dgvMyRentedComics)).EndInit(); // Added
             ResumeLayout(false);
             PerformLayout();
         }
@@ -279,6 +279,6 @@ namespace ComicRentalSystem_14Days
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelUser;
         // private System.Windows.Forms.Button btnRentComic;
         private System.Windows.Forms.Label lblMyRentedComicsHeader; // Added
-        // private System.Windows.Forms.DataGridView dgvMyRentedComics; // Added
+        private System.Windows.Forms.DataGridView dgvMyRentedComics; // Added
     }
 }

--- a/ComicRentalSystem_14Days/MainForm.cs
+++ b/ComicRentalSystem_14Days/MainForm.cs
@@ -62,10 +62,10 @@ namespace ComicRentalSystem_14Days
             this._logger?.Log("MainForm is loading.");
             // _comicService is guaranteed non-null by constructor, direct use.
             SetupDataGridView(); // Sets up dgvAvailableComics
-            // SetupMyRentedComicsDataGridView(); // Sets up dgvMyRentedComics
+            SetupMyRentedComicsDataGridView(); // Sets up dgvMyRentedComics
 
             LoadAvailableComics(); // Loads data for available comics
-            // LoadMyRentedComics();  // Loads data for member's rented comics
+            LoadMyRentedComics();  // Loads data for member's rented comics
 
             this._comicService.ComicsChanged += ComicService_ComicsChanged;
             dgvAvailableComics.SelectionChanged += dgvAvailableComics_SelectionChanged;
@@ -95,7 +95,7 @@ namespace ComicRentalSystem_14Days
         {
             this._logger?.Log("ComicsChanged event received, reloading available comics and member's rented comics.");
             LoadAvailableComics();
-            // LoadMyRentedComics(); // Also reload member's rented comics
+            LoadMyRentedComics(); // Also reload member's rented comics
         }
 
         private void SetupDataGridView()
@@ -265,108 +265,108 @@ namespace ComicRentalSystem_14Days
             }
         }
 
-        // private void SetupMyRentedComicsDataGridView()
-        // {
-        //     _logger?.Log("Setting up DataGridView for member's rented comics (dgvMyRentedComics).");
-        //     dgvMyRentedComics.AutoGenerateColumns = false;
-        //     dgvMyRentedComics.Columns.Clear();
-        //     dgvMyRentedComics.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
+        private void SetupMyRentedComicsDataGridView()
+        {
+            _logger?.Log("Setting up DataGridView for member's rented comics (dgvMyRentedComics).");
+            dgvMyRentedComics.AutoGenerateColumns = false;
+            dgvMyRentedComics.Columns.Clear();
+            dgvMyRentedComics.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
 
-        //     dgvMyRentedComics.Columns.Add(new DataGridViewTextBoxColumn { DataPropertyName = "Title", HeaderText = "書名", FillWeight = 35 });
-        //     dgvMyRentedComics.Columns.Add(new DataGridViewTextBoxColumn { DataPropertyName = "Author", HeaderText = "作者", FillWeight = 25 });
+            dgvMyRentedComics.Columns.Add(new DataGridViewTextBoxColumn { DataPropertyName = "Title", HeaderText = "書名", FillWeight = 35 });
+            dgvMyRentedComics.Columns.Add(new DataGridViewTextBoxColumn { DataPropertyName = "Author", HeaderText = "作者", FillWeight = 25 });
 
-        //     var rentalDateColumn = new DataGridViewTextBoxColumn {
-        //         DataPropertyName = "RentalDate",
-        //         HeaderText = "租借日期",
-        //         FillWeight = 20
-        //     };
-        //     rentalDateColumn.DefaultCellStyle.Format = "yyyy-MM-dd"; // Format as date only
-        //     dgvMyRentedComics.Columns.Add(rentalDateColumn);
+            var rentalDateColumn = new DataGridViewTextBoxColumn {
+                DataPropertyName = "RentalDate",
+                HeaderText = "租借日期",
+                FillWeight = 20
+            };
+            rentalDateColumn.DefaultCellStyle.Format = "yyyy-MM-dd"; // Format as date only
+            dgvMyRentedComics.Columns.Add(rentalDateColumn);
 
-        //     var returnDateColumn = new DataGridViewTextBoxColumn {
-        //         DataPropertyName = "ReturnDate",
-        //         HeaderText = "歸還日期",
-        //         FillWeight = 20
-        //     };
-        //     returnDateColumn.DefaultCellStyle.Format = "yyyy-MM-dd"; // Format as date only
-        //     dgvMyRentedComics.Columns.Add(returnDateColumn);
+            var returnDateColumn = new DataGridViewTextBoxColumn {
+                DataPropertyName = "ReturnDate",
+                HeaderText = "歸還日期",
+                FillWeight = 20
+            };
+            returnDateColumn.DefaultCellStyle.Format = "yyyy-MM-dd"; // Format as date only
+            dgvMyRentedComics.Columns.Add(returnDateColumn);
 
-        //     dgvMyRentedComics.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
-        //     dgvMyRentedComics.MultiSelect = false;
-        //     dgvMyRentedComics.ReadOnly = true;
-        //     dgvMyRentedComics.AllowUserToAddRows = false;
-        // }
+            dgvMyRentedComics.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
+            dgvMyRentedComics.MultiSelect = false;
+            dgvMyRentedComics.ReadOnly = true;
+            dgvMyRentedComics.AllowUserToAddRows = false;
+        }
 
-        // private void LoadMyRentedComics()
-        // {
-        //     if (_currentUser == null || _comicService == null || _memberService == null || _logger == null)
-        //     {
-        //         _logger?.LogWarning("LoadMyRentedComics: CurrentUser or critical services are null. Clearing DGV.");
-        //         if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
-        //         else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
-        //         return;
-        //     }
+        private void LoadMyRentedComics()
+        {
+            if (_currentUser == null || _comicService == null || _memberService == null || _logger == null)
+            {
+                _logger?.LogWarning("LoadMyRentedComics: CurrentUser or critical services are null. Clearing DGV.");
+                if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
+                else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
+                return;
+            }
 
-        //     if (_currentUser.Role != UserRole.Member)
-        //     {
-        //         _logger?.Log("LoadMyRentedComics: User is not a Member. Clearing DGV.");
-        //          if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
-        //         else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
-        //         return;
-        //     }
+            if (_currentUser.Role != UserRole.Member)
+            {
+                _logger?.Log("LoadMyRentedComics: User is not a Member. Clearing DGV.");
+                 if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
+                else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
+                return;
+            }
 
-        //     _logger?.Log($"LoadMyRentedComics: Loading comics for member '{_currentUser.Username}'.");
+            _logger?.Log($"LoadMyRentedComics: Loading comics for member '{_currentUser.Username}'.");
 
-        //     try
-        //     {
-        //         Member? currentMember = null;
-        //         try
-        //         {
-        //             currentMember = _memberService.GetMemberByUsername(_currentUser.Username);
-        //         }
-        //         catch (NotImplementedException nie)
-        //         {
-        //             _logger?.LogError($"LoadMyRentedComics: _memberService.GetMemberByUsername is not implemented. {nie.Message}");
-        //             if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
-        //             else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
-        //             return;
-        //         }
+            try
+            {
+                Member? currentMember = null;
+                try
+                {
+                    currentMember = _memberService.GetMemberByUsername(_currentUser.Username);
+                }
+                catch (NotImplementedException nie)
+                {
+                    _logger?.LogError($"LoadMyRentedComics: _memberService.GetMemberByUsername is not implemented. {nie.Message}");
+                    if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
+                    else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
+                    return;
+                }
 
-        //         if (currentMember == null)
-        //         {
-        //             _logger?.LogWarning($"LoadMyRentedComics: Member profile not found for username '{_currentUser.Username}'.");
-        //              if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
-        //             else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
-        //             return;
-        //         }
-        //         int currentMemberId = currentMember.Id;
+                if (currentMember == null)
+                {
+                    _logger?.LogWarning($"LoadMyRentedComics: Member profile not found for username '{_currentUser.Username}'.");
+                     if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
+                    else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
+                    return;
+                }
+                int currentMemberId = currentMember.Id;
 
-        //         var allComics = _comicService.GetAllComics();
-        //         var myRentedComics = allComics.Where(c => c.IsRented && c.RentedToMemberId == currentMemberId).ToList();
+                var allComics = _comicService.GetAllComics();
+                var myRentedComics = allComics.Where(c => c.IsRented && c.RentedToMemberId == currentMemberId).ToList();
 
-        //         Action updateDataSource = () => {
-        //             dgvMyRentedComics.DataSource = null;
-        //             dgvMyRentedComics.DataSource = myRentedComics;
-        //         };
+                Action updateDataSource = () => {
+                    dgvMyRentedComics.DataSource = null;
+                    dgvMyRentedComics.DataSource = myRentedComics;
+                };
 
-        //         if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired)
-        //         {
-        //             this.Invoke(updateDataSource);
-        //         }
-        //         else if (dgvMyRentedComics.IsHandleCreated)
-        //         {
-        //             updateDataSource();
-        //         }
-        //         _logger?.Log($"LoadMyRentedComics: Successfully loaded {myRentedComics.Count} rented comics for member ID {currentMemberId}.");
-        //     }
-        //     catch (Exception ex)
-        //     {
-        //         _logger?.LogError("LoadMyRentedComics: Error loading member's rented comics.", ex);
-        //         MessageBox.Show($"載入您的租借漫畫列表時發生錯誤: {ex.Message}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
-        //         if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
-        //         else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
-        //     }
-        // }
+                if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired)
+                {
+                    this.Invoke(updateDataSource);
+                }
+                else if (dgvMyRentedComics.IsHandleCreated)
+                {
+                    updateDataSource();
+                }
+                _logger?.Log($"LoadMyRentedComics: Successfully loaded {myRentedComics.Count} rented comics for member ID {currentMemberId}.");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError("LoadMyRentedComics: Error loading member's rented comics.", ex);
+                MessageBox.Show($"載入您的租借漫畫列表時發生錯誤: {ex.Message}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                if (dgvMyRentedComics.IsHandleCreated && this.InvokeRequired) { this.Invoke(new Action(() => dgvMyRentedComics.DataSource = null)); }
+                else if (dgvMyRentedComics.IsHandleCreated) { dgvMyRentedComics.DataSource = null; }
+            }
+        }
 
         private void 離開ToolStripMenuItem_Click(object sender, EventArgs e)
         {
@@ -531,7 +531,7 @@ namespace ComicRentalSystem_14Days
                         _logger?.Log($"Comic '{selectedComic.Title}' (ID: {selectedComic.Id}) rented to member ID {member.Id} (Username: {_currentUser.Username}) until {selectedReturnDate:yyyy-MM-dd}.");
                         MessageBox.Show($"漫畫 '{selectedComic.Title}' 已成功租借至 {selectedReturnDate:yyyy-MM-dd}。", "租借成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
                         LoadAvailableComics(); // Refresh the list of available comics
-                        // LoadMyRentedComics();  // Refresh the list of member's rented comics
+                        LoadMyRentedComics();  // Refresh the list of member's rented comics
                         dgvAvailableComics_SelectionChanged(null, EventArgs.Empty); // Update button state for btnRentComic
                     }
                     catch (Exception ex)


### PR DESCRIPTION
The DataGridView `dgvMyRentedComics` and its associated label `lblMyRentedComicsHeader` were causing compilation errors (CS0103, CS1061) due to being partially commented out in `MainForm.Designer.cs` and `MainForm.cs`.

This commit addresses the issue by:
1.  Uncommenting the declaration and initialization of `dgvMyRentedComics` and `lblMyRentedComicsHeader` in `MainForm.Designer.cs`.
2.  Uncommenting the related logic in `MainForm.cs`, including event handlers, setup methods (`SetupMyRentedComicsDataGridView`), and data loading methods (`LoadMyRentedComics`) for these components.

This should restore the 'My Rented Comics' functionality for member users.

Note: Full build and runtime testing of the Windows Forms application could not be completed due to limitations of the non-Windows build environment. The changes are based on the assumption that the uncommented code was previously functional.