### PR TITLE
feat: Implement 'All Comics Status' view for Admin

### DIFF
--- a/ComicRentalSystem_14Days/Models/AdminComicStatusViewModel.cs
+++ b/ComicRentalSystem_14Days/Models/AdminComicStatusViewModel.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace ComicRentalSystem_14Days.Models
+{
+    public class AdminComicStatusViewModel
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string Author { get; set; } = string.Empty;
+        public string Genre { get; set; } = string.Empty;
+        public string Isbn { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+        public string BorrowerName { get; set; } = string.Empty;
+        public string BorrowerPhoneNumber { get; set; } = string.Empty;
+        public DateTime? RentalDate { get; set; }
+        public DateTime? ReturnDate { get; set; }
+    }
+}


### PR DESCRIPTION
This commit introduces changes to the MainForm for administrators:

- The label "目前可借閱漫畫" is changed to "所有漫畫狀態".
- A new grid display shows all comics in the system, not just available ones.
- For each comic, the following information is displayed:
    - Title, Author
    - Status ("在館中" or "被借閱")
    - If rented: Borrower's Name, Borrower's Phone Number, Rental Date, Return Date.
- A new ViewModel `AdminComicStatusViewModel` was created to support this view.
- Existing functionality for Member users remains unchanged.
- The view correctly updates when comic data changes.