### PR TITLE
Fix: Redesign return time logic and UI

### DIFF
--- a/ComicRentalSystem_14Days/Forms/ComicManagementForm.cs
+++ b/ComicRentalSystem_14Days/Forms/ComicManagementForm.cs
@@ -84,11 +84,22 @@ namespace ComicRentalSystem_14Days.Forms
             var returnDateColumn = new DataGridViewTextBoxColumn
             {
                 DataPropertyName = nameof(Comic.ReturnDate), // "ReturnDate"
-                HeaderText = "歸還期限",
+                HeaderText = "預計歸還時間",
                 Width = 110 // Or another appropriate width
             };
             returnDateColumn.DefaultCellStyle.Format = "yyyy-MM-dd";
             dgvComics.Columns.Add(returnDateColumn);
+
+            // Add ActualReturnTime column
+            var actualReturnTimeColumn = new DataGridViewTextBoxColumn
+            {
+                DataPropertyName = nameof(Comic.ActualReturnTime),
+                HeaderText = "實際歸還時間",
+                Width = 120 // Or an appropriate width
+            };
+            actualReturnTimeColumn.DefaultCellStyle.Format = "yyyy-MM-dd HH:mm:ss"; // Include time
+            actualReturnTimeColumn.DefaultCellStyle.NullValue = ""; // Display empty if null
+            dgvComics.Columns.Add(actualReturnTimeColumn);
 
             dgvComics.Columns.Add(new DataGridViewTextBoxColumn { DataPropertyName = "Isbn", HeaderText = "ISBN", Width = 120 });
 

--- a/ComicRentalSystem_14Days/Forms/RentalForm.cs
+++ b/ComicRentalSystem_14Days/Forms/RentalForm.cs
@@ -375,7 +375,7 @@ namespace ComicRentalSystem_14Days.Forms
                         selectedComic.RentedToMemberId = selectedMember.Id;
                         selectedComic.RentalDate = DateTime.Now; // Set current date/time as rental date
                         selectedComic.ReturnDate = selectedReturnDate; // Set expected return date from dialog
-                        // ActualReturnTime remains null until the comic is actually returned
+                        selectedComic.ActualReturnTime = null; // Explicitly set to null
 
                         _comicService.UpdateComic(selectedComic);
 

--- a/ComicRentalSystem_14Days/Models/AdminComicStatusViewModel.cs
+++ b/ComicRentalSystem_14Days/Models/AdminComicStatusViewModel.cs
@@ -14,5 +14,6 @@ namespace ComicRentalSystem_14Days.Models
         public string BorrowerPhoneNumber { get; set; } = string.Empty;
         public DateTime? RentalDate { get; set; }
         public DateTime? ReturnDate { get; set; }
+        public DateTime? ActualReturnTime { get; set; }
     }
 }


### PR DESCRIPTION
This commit addresses issues with "Expected Return Time" and "Actual Return Time" in the comic rental system.

Key changes:

1.  **AdminComicStatusViewModel**: Added `ActualReturnTime` property to `AdminComicStatusViewModel.cs` to enable tracking of actual return dates in relevant views.
2.  **ComicManagementForm ("All Comics Status" view)**:
    *   Renamed the "歸還期限" (Return Deadline) column to "預計歸還時間" (Expected Return Time) for clarity.
    *   Added a new column "實際歸還時間" (Actual Return Time) to display the actual date and time a comic was returned. Null values will be displayed as empty strings.
3.  **RentalForm (Rental Management Form)**:
    *   Ensured that `ActualReturnTime` is explicitly set to `null` when a comic is rented. This prevents stale data from being carried over and resolves an issue where the actual return time might have incorrectly appeared the same as the rental date.
    *   Verified that the logic for setting the actual return time upon return (`btnReturn_Click`) and for displaying it in the rental details grid (`LoadRentalDetails` and `SetupRentedComicsDataGridView`) is correct.

These changes improve the accuracy and clarity of rental and return time information within the system.