### PR TITLE
Translate application to Traditional Chinese

### DIFF
--- a/ComicRentalSystem_14Days/Forms/ComicEditForm.cs
+++ b/ComicRentalSystem_14Days/Forms/ComicEditForm.cs
@@ -31,8 +31,8 @@ namespace ComicRentalSystem_14Days.Forms
             _editableComic = comicToEdit;
             _isEditMode = (_editableComic != null);
 
-            LogActivity($"ComicEditForm initializing. Mode: {(_isEditMode ? "Edit" : "Add")}" +
-                        (_isEditMode && _editableComic != null ? $", ComicID: {_editableComic.Id}" : ""));
+            LogActivity($"漫畫編輯表單初始化中。模式: {(_isEditMode ? "編輯" : "新增")}" +
+                        (_isEditMode && _editableComic != null ? $", 漫畫ID: {_editableComic.Id}" : ""));
 
             if (_isEditMode && _editableComic != null)
             {
@@ -45,18 +45,18 @@ namespace ComicRentalSystem_14Days.Forms
                 chkIsRented.Checked = false;
                 chkIsRented.Enabled = false;
             }
-            LogActivity("ComicEditForm initialized with services.");
+            LogActivity("漫畫編輯表單已使用服務初始化。");
         }
 
         private void LoadComicData()
         {
             if (_editableComic == null)
             {
-                LogActivity("LoadComicData called but _editableComic is null (should not happen in edit mode).");
+                LogActivity("LoadComicData 已呼叫，但 _editableComic 為空 (在編輯模式下不應發生)。");
                 return;
             }
 
-            LogActivity($"Loading data for comic ID: {_editableComic.Id}, Title: '{_editableComic.Title}'.");
+            LogActivity($"正在載入漫畫ID: {_editableComic.Id}, 書名: '{_editableComic.Title}' 的資料。");
             txtTitle.Text = _editableComic.Title;
             txtAuthor.Text = _editableComic.Author;
             txtIsbn.Text = _editableComic.Isbn;
@@ -64,7 +64,7 @@ namespace ComicRentalSystem_14Days.Forms
             chkIsRented.Checked = _editableComic.IsRented;
             chkIsRented.Enabled = false;
 
-            LogActivity("Comic data loaded into form controls.");
+            LogActivity("漫畫資料已載入表單控制項。");
         }
 
         private void btnSave_Click(object sender, EventArgs e)
@@ -72,36 +72,36 @@ namespace ComicRentalSystem_14Days.Forms
             if (_comicService == null)
             {
                 MessageBox.Show("服務未初始化，無法儲存。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                LogErrorActivity("Save button clicked, but _comicService is null.");
+                LogErrorActivity("儲存按鈕已點擊，但 _comicService 為空。");
                 return;
             }
 
-            LogActivity("Save button clicked.");
+            LogActivity("儲存按鈕已點擊。");
 
             if (string.IsNullOrWhiteSpace(txtTitle.Text))
             {
-                LogActivity("Validation failed: Title is empty.");
+                LogActivity("驗證失敗: 書名為空。");
                 MessageBox.Show("書名不得為空。", "驗證錯誤", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 txtTitle.Focus();
                 return;
             }
             if (string.IsNullOrWhiteSpace(txtAuthor.Text))
             {
-                LogActivity("Validation failed: Author is empty.");
+                LogActivity("驗證失敗: 作者為空。");
                 MessageBox.Show("作者不得為空。", "驗證錯誤", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 txtAuthor.Focus();
                 return;
             }
             if (string.IsNullOrWhiteSpace(txtGenre.Text))
             {
-                LogActivity("Validation failed: Genre is empty.");
+                LogActivity("驗證失敗: 類型為空。");
                 MessageBox.Show("類型不得為空。", "驗證錯誤", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 txtGenre.Focus();
                 return;
             }
             if (string.IsNullOrWhiteSpace(txtIsbn.Text))
             {
-                LogActivity("Validation failed: ISBN is empty.");
+                LogActivity("驗證失敗: ISBN為空。");
                 MessageBox.Show("ISBN不得為空。", "驗證錯誤", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 txtIsbn.Focus();
                 return;
@@ -111,18 +111,18 @@ namespace ComicRentalSystem_14Days.Forms
             {
                 if (_isEditMode && _editableComic != null)
                 {
-                    LogActivity($"Attempting to save changes for existing comic ID: {_editableComic.Id}.");
+                    LogActivity($"正在嘗試儲存現有漫畫ID: {_editableComic.Id} 的變更。");
                     _editableComic.Title = txtTitle.Text.Trim();
                     _editableComic.Author = txtAuthor.Text.Trim();
                     _editableComic.Isbn = txtIsbn.Text.Trim();
                     _editableComic.Genre = txtGenre.Text.Trim();
                     _comicService.UpdateComic(_editableComic);
-                    LogActivity($"Comic ID: {_editableComic.Id} updated successfully.");
+                    LogActivity($"漫畫ID: {_editableComic.Id} 已成功更新。");
                     MessageBox.Show("漫畫資料已更新。", "成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
                 else
                 {
-                    LogActivity("Attempting to add new comic.");
+                    LogActivity("正在嘗試新增漫畫。");
                     Comic newComic = new Comic
                     {
                         Title = txtTitle.Text.Trim(),
@@ -133,31 +133,31 @@ namespace ComicRentalSystem_14Days.Forms
                         RentedToMemberId = 0
                     };
                     _comicService.AddComic(newComic);
-                    LogActivity($"New comic '{newComic.Title}' (ID: {newComic.Id}) added successfully.");
+                    LogActivity($"新漫畫 '{newComic.Title}' (ID: {newComic.Id}) 已成功新增。");
                     MessageBox.Show("漫畫已成功新增。", "成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
 
                 this.DialogResult = DialogResult.OK;
-                LogActivity("ComicEditForm closing with DialogResult.OK.");
+                LogActivity("漫畫編輯表單正在以 DialogResult.OK 關閉。");
                 this.Close();
             }
             catch (Exception ex)
             {
-                LogErrorActivity($"Error while saving comic: {ex.Message}", ex);
+                LogErrorActivity($"儲存漫畫時發生錯誤: {ex.Message}", ex);
                 MessageBox.Show($"儲存漫畫時發生錯誤: {ex.Message}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
         private void btnCancel_Click(object sender, EventArgs e)
         {
-            LogActivity("Cancel button clicked. ComicEditForm closing with DialogResult.Cancel.");
+            LogActivity("取消按鈕已點擊。漫畫編輯表單正在以 DialogResult.Cancel 關閉。");
             this.DialogResult = DialogResult.Cancel;
             this.Close();
         }
 
         private void ComicEditForm_Load(object sender, EventArgs e)
         {
-            LogActivity("ComicEditForm finished loading.");
+            LogActivity("漫畫編輯表單已完成載入。");
         }
     }
 }

--- a/ComicRentalSystem_14Days/Forms/LoginForm.cs
+++ b/ComicRentalSystem_14Days/Forms/LoginForm.cs
@@ -27,7 +27,7 @@ namespace ComicRentalSystem_14Days.Forms
             _comicService = comicService ?? throw new ArgumentNullException(nameof(comicService));
             _memberService = memberService ?? throw new ArgumentNullException(nameof(memberService));
             _reloadService = reloadService ?? throw new ArgumentNullException(nameof(reloadService));
-            _logger.Log("LoginForm initialized.");
+            _logger.Log("登入表單已初始化。");
 
             // Set password char
             txtPassword.PasswordChar = '*';
@@ -39,7 +39,7 @@ namespace ComicRentalSystem_14Days.Forms
         private void btnRegister_Click(object? sender, EventArgs e)
 
         {
-            _logger.Log("Register button clicked.");
+            _logger.Log("註冊按鈕已點擊。");
             RegistrationForm regForm = new RegistrationForm(_logger, _authService, _memberService);
             regForm.ShowDialog(this);
         }
@@ -52,16 +52,16 @@ namespace ComicRentalSystem_14Days.Forms
             if (string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password))
             {
                 MessageBox.Show("請輸入使用者名稱和密碼。", "登入失敗", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                _logger.Log("Login attempt failed: Username or password empty.");
+                _logger.Log("登入嘗試失敗: 使用者名稱或密碼為空。");
                 return;
             }
 
-            _logger.Log($"Login attempt for user: {username}");
+            _logger.Log($"使用者登入嘗試: {username}");
             User? user = _authService.Login(username, password);
 
             if (user != null)
             {
-                _logger.Log($"User '{username}' logged in successfully. Role: {user.Role}.");
+                _logger.Log($"使用者 '{username}' 成功登入。角色: {user.Role}。");
                 this.Hide(); // Hide login form
                 MainForm mainForm = new MainForm(_logger, _comicService, _memberService, _reloadService, user);
                 mainForm.FormClosed += (s, args) => this.Close(); // Close login form when main form closes
@@ -69,7 +69,7 @@ namespace ComicRentalSystem_14Days.Forms
             }
             else
             {
-                _logger.Log($"Login failed for user: {username}. Invalid credentials.");
+                _logger.Log($"使用者 '{username}' 登入失敗。無效的憑證。");
                 MessageBox.Show("使用者名稱或密碼錯誤。", "登入失敗", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 txtUsername.Clear(); // Clear username field
                 txtPassword.Clear(); // Clear password field
@@ -78,7 +78,7 @@ namespace ComicRentalSystem_14Days.Forms
 
         private void LoginForm_Load(object sender, EventArgs e)
         {
-            _logger.Log("LoginForm loaded.");
+            _logger.Log("登入表單已載入。");
             // You can add any initialization logic here if needed when the form loads
         }
     }

--- a/ComicRentalSystem_14Days/Forms/MemberEditForm.cs
+++ b/ComicRentalSystem_14Days/Forms/MemberEditForm.cs
@@ -31,8 +31,8 @@ namespace ComicRentalSystem_14Days.Forms
             _editableMember = memberToEdit;
             _isEditMode = (_editableMember != null);
 
-            LogActivity($"MemberEditForm initializing. Mode: {(_isEditMode ? "Edit" : "Add")}" +
-                        (_isEditMode && _editableMember != null ? $", MemberID: {_editableMember.Id}" : ""));
+            LogActivity($"會員編輯表單初始化中。模式: {(_isEditMode ? "編輯" : "新增")}" +
+                        (_isEditMode && _editableMember != null ? $", 會員ID: {_editableMember.Id}" : ""));
 
             if (_isEditMode && _editableMember != null)
             {
@@ -43,21 +43,21 @@ namespace ComicRentalSystem_14Days.Forms
             {
                 this.Text = "新增會員";
             }
-            LogActivity("MemberEditForm initialized with services.");
+            LogActivity("會員編輯表單已使用服務初始化。");
         }
 
         private void LoadMemberData()
         {
             if (_editableMember == null)
             {
-                LogActivity("LoadMemberData called but _editableMember is null (should not happen in edit mode).");
+                LogActivity("LoadMemberData 已呼叫，但 _editableMember 為空 (在編輯模式下不應發生)。");
                 return;
             }
 
-            LogActivity($"Loading data for member ID: {_editableMember.Id}, Name: '{_editableMember.Name}'.");
+            LogActivity($"正在載入會員ID: {_editableMember.Id}, 姓名: '{_editableMember.Name}' 的資料。");
             txtName.Text = _editableMember.Name;
             txtPhoneNumber.Text = _editableMember.PhoneNumber;
-            LogActivity("Member data loaded into form controls.");
+            LogActivity("會員資料已載入表單控制項。");
         }
 
         private void btnSaveMember_Click(object sender, EventArgs e)
@@ -65,15 +65,15 @@ namespace ComicRentalSystem_14Days.Forms
             if (_memberService == null)
             {
                 MessageBox.Show("服務未初始化，無法儲存。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                LogErrorActivity("Save Member button clicked, but _memberService is null.");
+                LogErrorActivity("儲存會員按鈕已點擊，但 _memberService 為空。");
                 return;
             }
 
-            LogActivity("Save Member button clicked.");
+            LogActivity("儲存會員按鈕已點擊。");
 
             if (string.IsNullOrWhiteSpace(txtName.Text))
             {
-                LogActivity("Validation failed: Name is empty.");
+                LogActivity("驗證失敗: 姓名不得為空。");
                 MessageBox.Show("姓名不得為空。", "驗證錯誤", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 txtName.Focus();
                 return;
@@ -81,7 +81,7 @@ namespace ComicRentalSystem_14Days.Forms
 
             if (string.IsNullOrWhiteSpace(txtPhoneNumber.Text))
             {
-                LogActivity("Validation failed: Phone number is empty.");
+                LogActivity("驗證失敗: 電話號碼不得為空。");
                 MessageBox.Show("電話號碼不得為空。", "驗證錯誤", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 txtPhoneNumber.Focus();
                 return;
@@ -89,7 +89,7 @@ namespace ComicRentalSystem_14Days.Forms
 
             if (!txtPhoneNumber.Text.All(char.IsDigit))
             {
-                LogActivity("Validation failed: Phone number contains non-digit characters.");
+                LogActivity("驗證失敗: 電話號碼包含非數字字元。");
                 MessageBox.Show("電話號碼只能包含數字。", "驗證錯誤", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 txtPhoneNumber.Focus();
                 return;
@@ -99,47 +99,47 @@ namespace ComicRentalSystem_14Days.Forms
             {
                 if (_isEditMode && _editableMember != null)
                 {
-                    LogActivity($"Attempting to save changes for existing member ID: {_editableMember.Id}.");
+                    LogActivity($"正在嘗試儲存現有會員ID: {_editableMember.Id} 的變更。");
                     _editableMember.Name = txtName.Text.Trim();
                     _editableMember.PhoneNumber = txtPhoneNumber.Text.Trim();
                     _memberService.UpdateMember(_editableMember);
-                    LogActivity($"Member ID: {_editableMember.Id} updated successfully.");
+                    LogActivity($"會員ID: {_editableMember.Id} 已成功更新。");
                     MessageBox.Show("會員資料已更新。", "成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
                 else
                 {
-                    LogActivity("Attempting to add new member.");
+                    LogActivity("正在嘗試新增會員。");
                     Member newMember = new Member
                     {
                         Name = txtName.Text.Trim(),
                         PhoneNumber = txtPhoneNumber.Text.Trim()
                     };
                     _memberService.AddMember(newMember);
-                    LogActivity($"New member '{newMember.Name}' (ID: {newMember.Id}) added successfully.");
+                    LogActivity($"新會員 '{newMember.Name}' (ID: {newMember.Id}) 已成功新增。");
                     MessageBox.Show("會員已成功新增。", "成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
 
                 this.DialogResult = DialogResult.OK;
-                LogActivity("MemberEditForm closing with DialogResult.OK.");
+                LogActivity("會員編輯表單正在以 DialogResult.OK 關閉。");
                 this.Close();
             }
             catch (Exception ex)
             {
-                LogErrorActivity($"Error while saving member: {ex.Message}", ex);
+                LogErrorActivity($"儲存會員時發生錯誤: {ex.Message}", ex);
                 MessageBox.Show($"儲存會員時發生錯誤: {ex.Message}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
         private void btnCancelMember_Click(object sender, EventArgs e)
         {
-            LogActivity("Cancel Member button clicked. MemberEditForm closing with DialogResult.Cancel.");
+            LogActivity("取消會員按鈕已點擊。會員編輯表單正在以 DialogResult.Cancel 關閉。");
             this.DialogResult = DialogResult.Cancel;
             this.Close();
         }
 
         private void MemberEditForm_Load(object sender, EventArgs e)
         {
-            LogActivity("MemberEditForm finished loading.");
+            LogActivity("會員編輯表單已完成載入。");
         }
     }
 }

--- a/ComicRentalSystem_14Days/Forms/RegistrationForm.cs
+++ b/ComicRentalSystem_14Days/Forms/RegistrationForm.cs
@@ -22,7 +22,7 @@ namespace ComicRentalSystem_14Days.Forms
 
             txtPassword.PasswordChar = '*';
             txtConfirmPassword.PasswordChar = '*';
-            _logger.Log("RegistrationForm initialized.");
+            _logger.Log("註冊表單已初始化。");
         }
 
         private void btnRegister_Click(object sender, EventArgs e)
@@ -37,35 +37,35 @@ namespace ComicRentalSystem_14Days.Forms
             if (string.IsNullOrWhiteSpace(username))
             {
                 MessageBox.Show("使用者名稱不能為空。", "註冊失敗", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                _logger.Log("Registration attempt failed: Username empty.");
+                _logger.Log("註冊嘗試失敗: 使用者名稱為空。");
                 return;
             }
 
             if (string.IsNullOrWhiteSpace(name))
             {
                 MessageBox.Show("姓名不能為空。", "註冊失敗", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                _logger.Log("Registration attempt failed: Name empty.");
+                _logger.Log("註冊嘗試失敗: 姓名為空。");
                 return;
             }
 
             if (string.IsNullOrWhiteSpace(phoneNumber))
             {
                 MessageBox.Show("電話號碼不能為空。", "註冊失敗", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                _logger.Log("Registration attempt failed: Phone number empty.");
+                _logger.Log("註冊嘗試失敗: 電話號碼為空。");
                 return;
             }
 
             if (string.IsNullOrWhiteSpace(password))
             {
                 MessageBox.Show("密碼不能為空。", "註冊失敗", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                _logger.Log("Registration attempt failed: Password empty.");
+                _logger.Log("註冊嘗試失敗: 密碼為空。");
                 return;
             }
 
             if (password.Length < 6)
             {
                 MessageBox.Show("密碼長度至少需6個字元。", "註冊失敗", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                _logger.Log("Registration attempt failed: Password too short.");
+                _logger.Log("註冊嘗試失敗: 密碼過短。");
                 txtPassword.Clear();
                 txtConfirmPassword.Clear();
                 return;
@@ -74,25 +74,25 @@ namespace ComicRentalSystem_14Days.Forms
             if (password != confirmPassword)
             {
                 MessageBox.Show("密碼與確認密碼不相符。", "註冊失敗", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                _logger.Log("Registration attempt failed: Passwords do not match.");
+                _logger.Log("註冊嘗試失敗: 密碼不相符。");
                 txtPassword.Clear();
                 txtConfirmPassword.Clear();
                 return;
             }
 
-            _logger.Log($"Registration attempt for user: {username}, Name: {name}, Phone: {phoneNumber}, Role: {selectedRole}");
+            _logger.Log($"使用者註冊嘗試: {username}, 姓名: {name}, 電話: {phoneNumber}, 角色: {selectedRole}");
             bool success = _authService.Register(username, password, selectedRole);
 
             if (success)
             {
-                _logger.Log($"User '{username}' (from txtUsername) registered successfully as {selectedRole}.");
+                _logger.Log($"使用者 '{username}' (來自txtUsername) 已成功註冊為 {selectedRole}。");
                 try
                 {
                     // Create Member object, ensuring Username is populated from txtUsername.Text
                     // Name (for display/other purposes) is from txtName.Text
                     Member newMember = new Member { Name = name, PhoneNumber = phoneNumber, Username = username };
                     _memberService.AddMember(newMember);
-                    _logger.Log($"Member record created for Name: {name}, Username: {username}, Phone: {phoneNumber}");
+                    _logger.Log($"已為姓名: {name}, 使用者名稱: {username}, 電話: {phoneNumber} 建立會員記錄。");
 
                     MessageBox.Show($"使用者 '{username}' (姓名: {name}) 已成功註冊，會員資料也已建立。", "註冊成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     // Optionally close the form or clear fields
@@ -104,7 +104,7 @@ namespace ComicRentalSystem_14Days.Forms
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError($"Successfully registered user '{username}' but failed to create member record. Error: {ex.Message}", ex);
+                    _logger.LogError($"成功註冊使用者 '{username}' 但建立會員記錄失敗。錯誤: {ex.Message}", ex);
                     MessageBox.Show($"使用者 '{username}' 註冊成功，但建立會員資料時發生錯誤。請聯繫管理員。\n錯誤: {ex.Message}", "註冊部分成功", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     // User is registered, but member creation failed. Decide on cleanup or leave as is.
                     // For now, clear fields as user registration part was successful.
@@ -117,7 +117,7 @@ namespace ComicRentalSystem_14Days.Forms
             }
             else
             {
-                _logger.Log($"Registration failed for user: {username}. Username might already exist.");
+                _logger.Log($"使用者 '{username}' 註冊失敗。使用者名稱可能已存在。");
                 MessageBox.Show($"註冊失敗。使用者名稱 '{username}' 可能已被使用。", "註冊失敗", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 // Clear username only if it's a duplicate issue, others can remain for correction
                 txtUsername.Clear();
@@ -126,7 +126,7 @@ namespace ComicRentalSystem_14Days.Forms
 
         private void RegistrationForm_Load(object sender, EventArgs e)
         {
-            _logger.Log("RegistrationForm loaded.");
+            _logger.Log("註冊表單已載入。");
         }
     }
 }

--- a/ComicRentalSystem_14Days/Forms/RentalForm.cs
+++ b/ComicRentalSystem_14Days/Forms/RentalForm.cs
@@ -45,12 +45,12 @@ namespace ComicRentalSystem_14Days.Forms
                 _memberService.MembersChanged += Service_DataChanged;
             }
 
-            LogActivity("RentalForm initializing with services.");
+            LogActivity("租借表單初始化中 (使用服務)。");
         }
 
         private void RentalForm_Load(object sender, EventArgs e)
         {
-            LogActivity("RentalForm loading data.");
+            LogActivity("租借表單正在載入資料。");
             if (_comicService != null && _memberService != null)
             {
                 SetupRentedComicsDataGridView();
@@ -61,7 +61,7 @@ namespace ComicRentalSystem_14Days.Forms
                 _reloadService?.Start(
                     async () =>
                     {
-                        LogActivity("auto reloading data start");
+                        LogActivity("自動重新載入資料開始");
                         _comicService?.Reload();
                         _memberService?.Reload(); // Added call to MemberService.Reload
                         await Task.CompletedTask;
@@ -74,11 +74,11 @@ namespace ComicRentalSystem_14Days.Forms
                     LoadAvailableComics();
                     LoadRentalDetails(); // Updated call
                 }
-                LogActivity("RentalForm loaded successfully with data.");
+                LogActivity("租借表單已成功載入資料。");
             }
             else
             {
-                LogActivity("RentalForm loaded (design mode or services not provided). Skipping data load.");
+                LogActivity("租借表單已載入 (設計模式或未提供服務)。正在跳過資料載入。");
             }
         }
 
@@ -86,7 +86,7 @@ namespace ComicRentalSystem_14Days.Forms
         {
             if (_comicService == null || _memberService == null) return;
 
-            LogActivity($"DataChanged event received from {(sender is ComicService ? "ComicService" : "MemberService")}. Refreshing UI.");
+            LogActivity($"從 {(sender is ComicService ? "ComicService" : "MemberService")} 收到資料變更事件。正在更新UI。");
             if (this.IsHandleCreated && !this.IsDisposed)
             {
                 if (this.InvokeRequired)
@@ -126,7 +126,7 @@ namespace ComicRentalSystem_14Days.Forms
         {
             if (_memberService == null) return;
 
-            LogActivity("Loading members into cmbMembers.");
+            LogActivity("正在將會員載入到 cmbMembers。");
             try
             {
                 var members = _memberService.GetAllMembers();
@@ -143,11 +143,11 @@ namespace ComicRentalSystem_14Days.Forms
                 {
                     cmbMembers.SelectedIndex = -1;
                 }
-                LogActivity($"Loaded {members.Count} members into cmbMembers.");
+                LogActivity($"已將 {members.Count} 位會員載入到 cmbMembers。");
             }
             catch (Exception ex)
             {
-                LogErrorActivity("Error loading members into cmbMembers.", ex);
+                LogErrorActivity("將會員載入到 cmbMembers 時發生錯誤。", ex);
                 MessageBox.Show("載入會員列表時發生錯誤，請查看日誌。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
@@ -156,7 +156,7 @@ namespace ComicRentalSystem_14Days.Forms
         {
             if (_comicService == null) return;
 
-            LogActivity("Loading available (not rented) comics into cmbComics.");
+            LogActivity("正在將可借閱 (未租借) 的漫畫載入到 cmbComics。");
             try
             {
                 var availableComics = _comicService.GetAllComics().Where(c => !c.IsRented).ToList();
@@ -174,11 +174,11 @@ namespace ComicRentalSystem_14Days.Forms
                 {
                     if (cmbComics.SelectedIndex == -1) cmbComics.SelectedIndex = 0;
                 }
-                LogActivity($"Loaded {availableComics.Count} available comics into cmbComics.");
+                LogActivity($"已將 {availableComics.Count} 本可借閱漫畫載入到 cmbComics。");
             }
             catch (Exception ex)
             {
-                LogErrorActivity("Error loading available comics into cmbComics.", ex);
+                LogErrorActivity("將可借閱漫畫載入到 cmbComics 時發生錯誤。", ex);
                 MessageBox.Show("載入可用漫畫列表時發生錯誤，請查看日誌。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
@@ -191,7 +191,7 @@ namespace ComicRentalSystem_14Days.Forms
             return;
         }
 
-        LogActivity("Loading all rental details for Admin View.");
+        LogActivity("正在為管理員視圖載入所有租借詳細資料。");
         try
         {
             var allComics = _comicService.GetAllComics();
@@ -203,12 +203,12 @@ namespace ComicRentalSystem_14Days.Forms
             Member? selectedMember = cmbMembers.SelectedItem as Member;
             if (selectedMember != null)
             {
-                LogActivity($"Filtering rental details for selected member: {selectedMember.Name} (ID: {selectedMember.Id})");
+                LogActivity($"正在為選定會員篩選租借詳細資料: {selectedMember.Name} (ID: {selectedMember.Id})");
                 rentedComicsQuery = rentedComicsQuery.Where(c => c.RentedToMemberId == selectedMember.Id);
             }
             else
             {
-                LogActivity("No specific member selected. Loading all rented comics.");
+                LogActivity("未選定特定會員。正在載入所有已租借漫畫。");
             }
 
             var rentalDetails = rentedComicsQuery
@@ -219,7 +219,7 @@ namespace ComicRentalSystem_14Days.Forms
                     {
                         MemberId = member?.Id ?? 0,
                         MemberName = member?.Name ?? "未知會員",
-                        MemberPhoneNumber = member?.PhoneNumber ?? "N/A",
+                        MemberPhoneNumber = member?.PhoneNumber ?? "無",
                         ComicId = comic.Id,
                         ComicTitle = comic.Title,
                         RentalDate = comic.RentalDate,
@@ -234,18 +234,18 @@ namespace ComicRentalSystem_14Days.Forms
                 dgvRentedComics.DataSource = null;
                 dgvRentedComics.DataSource = rentalDetails;
             }
-            LogActivity($"Loaded {rentalDetails.Count} rental details.");
+            LogActivity($"已載入 {rentalDetails.Count} 筆租借詳細資料。");
         }
         catch (Exception ex)
         {
-            LogErrorActivity("Error loading rental details.", ex);
+            LogErrorActivity("載入租借詳細資料時發生錯誤。", ex);
             MessageBox.Show("載入租借詳細資料時發生錯誤，請查看日誌。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
     }
 
     private void SetupRentedComicsDataGridView()
     {
-        LogActivity("Setting up dgvRentedComics for Admin View.");
+        LogActivity("正在為管理員視圖設定 dgvRentedComics。");
         dgvRentedComics.AutoGenerateColumns = false;
         dgvRentedComics.Columns.Clear();
         dgvRentedComics.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
@@ -284,7 +284,7 @@ namespace ComicRentalSystem_14Days.Forms
         dgvRentedComics.MultiSelect = false;
         dgvRentedComics.ReadOnly = true;
         dgvRentedComics.AllowUserToAddRows = false;
-        LogActivity("dgvRentedComics setup complete for Admin View.");
+        LogActivity("dgvRentedComics 管理員視圖設定完成。");
     }
 
         private void cmbMembers_SelectedIndexChanged(object sender, EventArgs e)
@@ -293,11 +293,11 @@ namespace ComicRentalSystem_14Days.Forms
 
             if (cmbMembers.SelectedItem is Member selectedMember)
             {
-                LogActivity($"Member selection changed. Selected Member ID: {selectedMember.Id}, Name: {selectedMember.Name}. Refreshing related comic lists.");
+                LogActivity($"會員選擇已變更。選定會員ID: {selectedMember.Id}, 姓名: {selectedMember.Name}。正在更新相關漫畫列表。");
             }
             else
             {
-                LogActivity("Member selection cleared or invalid. Refreshing related comic lists.");
+                LogActivity("會員選擇已清除或無效。正在更新相關漫畫列表。");
             }
             LoadAvailableComics();
         LoadRentalDetails(); // Updated call
@@ -310,18 +310,18 @@ namespace ComicRentalSystem_14Days.Forms
                 MessageBox.Show("服務未初始化，無法執行操作。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
-            LogActivity("Rent button clicked.");
+            LogActivity("租借按鈕已點擊。");
 
             if (cmbMembers.SelectedValue == null)
             {
                 MessageBox.Show("請選擇一位會員。", "租借提示", MessageBoxButtons.OK, MessageBoxIcon.Information);
-                LogActivity("Rent action aborted: No member selected.");
+                LogActivity("租借操作中止: 未選擇會員。");
                 return;
             }
             if (cmbComics.SelectedValue == null)
             {
                 MessageBox.Show("請選擇一本要租借的漫畫。", "租借提示", MessageBoxButtons.OK, MessageBoxIcon.Information);
-                LogActivity("Rent action aborted: No comic selected.");
+                LogActivity("租借操作中止: 未選擇漫畫。");
                 return;
             }
 
@@ -334,14 +334,14 @@ namespace ComicRentalSystem_14Days.Forms
             if (selectedMember == null)
             {
                 MessageBox.Show("選擇的會員資料無效，可能已被刪除。", "租借錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                LogErrorActivity($"Rent action failed: Selected member with ID {memberId} not found.");
+                LogErrorActivity($"租借操作失敗: 找不到ID為 {memberId} 的選定會員。");
                 RefreshUIDataSafely();
                 return;
             }
             if (selectedComic == null)
             {
                 MessageBox.Show("選擇的漫畫資料無效，可能已被刪除或已被租借。", "租借錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                LogErrorActivity($"Rent action failed: Selected comic with ID {comicId} not found.");
+                LogErrorActivity($"租借操作失敗: 找不到ID為 {comicId} 的選定漫畫。");
                 RefreshUIDataSafely();
                 return;
             }
@@ -351,7 +351,7 @@ namespace ComicRentalSystem_14Days.Forms
                 Member? currentRenter = _memberService.GetMemberById(selectedComic.RentedToMemberId);
                 string renterName = currentRenter != null ? currentRenter.Name : "未知會員";
                 MessageBox.Show($"漫畫 '{selectedComic.Title}' 已被會員 '{renterName}' (ID: {selectedComic.RentedToMemberId}) 租借。", "租借失敗", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                LogActivity($"Rent action failed: Comic '{selectedComic.Title}' (ID: {comicId}) is already rented by member ID {selectedComic.RentedToMemberId}.");
+                LogActivity($"租借操作失敗: 漫畫 '{selectedComic.Title}' (ID: {comicId}) 已被會員ID {selectedComic.RentedToMemberId} 租借。");
                 RefreshUIDataSafely();
                 return;
             }
@@ -365,11 +365,11 @@ namespace ComicRentalSystem_14Days.Forms
 
                 using (RentalPeriodForm rentalDialog = new RentalPeriodForm(minRentalReturnDate, maxRentalReturnDate))
                 {
-                    LogActivity($"Showing RentalPeriodForm for comic '{selectedComic.Title}' to member '{selectedMember.Name}'. MinDate: {minRentalReturnDate:yyyy-MM-dd}, MaxDate: {maxRentalReturnDate:yyyy-MM-dd}");
+                    LogActivity($"正在為會員 '{selectedMember.Name}' 的漫畫 '{selectedComic.Title}' 顯示租借期限表單。最小日期: {minRentalReturnDate:yyyy-MM-dd}, 最大日期: {maxRentalReturnDate:yyyy-MM-dd}");
                     if (rentalDialog.ShowDialog(this) == DialogResult.OK)
                     {
                         DateTime selectedReturnDate = rentalDialog.SelectedReturnDate;
-                        LogActivity($"RentalPeriodForm accepted. Selected return date: {selectedReturnDate:yyyy-MM-dd}");
+                        LogActivity($"租借期限表單已接受。選定歸還日期: {selectedReturnDate:yyyy-MM-dd}");
 
                         selectedComic.IsRented = true;
                         selectedComic.RentedToMemberId = selectedMember.Id;
@@ -379,14 +379,14 @@ namespace ComicRentalSystem_14Days.Forms
 
                         _comicService.UpdateComic(selectedComic);
 
-                        LogActivity($"Comic '{selectedComic.Title}' (ID: {comicId}) successfully rented to member '{selectedMember.Name}' (ID: {memberId}). RentalDate: {selectedComic.RentalDate:yyyy-MM-dd HH:mm}, ExpectedReturnDate: {selectedComic.ReturnDate:yyyy-MM-dd}.");
+                        LogActivity($"漫畫 '{selectedComic.Title}' (ID: {comicId}) 已成功租借給會員 '{selectedMember.Name}' (ID: {memberId})。租借日期: {selectedComic.RentalDate:yyyy-MM-dd HH:mm}, 預計歸還日期: {selectedComic.ReturnDate:yyyy-MM-dd}。");
                         MessageBox.Show($"漫畫 '{selectedComic.Title}' 已成功租借給會員 '{selectedMember.Name}'。\n租借日期: {selectedComic.RentalDate:yyyy-MM-dd}\n預計歸還日期: {selectedComic.ReturnDate:yyyy-MM-dd}", "租借成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
                         LoadRentalDetails(); // Refresh the list of rented comics
                         LoadAvailableComics(); // Refresh the list of available comics
                     }
                     else
                     {
-                        LogActivity($"RentalPeriodForm cancelled by user for comic '{selectedComic.Title}' to member '{selectedMember.Name}'. Rental process aborted.");
+                        LogActivity($"使用者已為會員 '{selectedMember.Name}' 的漫畫 '{selectedComic.Title}' 取消租借期限表單。租借流程中止。");
                         // Optionally, inform the user that the rental was cancelled if not obvious
                         // MessageBox.Show("租借操作已取消。", "提示", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     }
@@ -394,7 +394,7 @@ namespace ComicRentalSystem_14Days.Forms
             }
             catch (Exception ex)
             {
-                LogErrorActivity($"Error during rent operation for comic ID: {comicId} to member ID: {memberId}.", ex);
+                LogErrorActivity($"為會員ID: {memberId} 租借漫畫ID: {comicId} 時發生錯誤。", ex);
                 MessageBox.Show($"租借漫畫時發生錯誤: {ex.Message}\n請查看日誌以獲取詳細資訊。", "租借錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
@@ -407,11 +407,11 @@ namespace ComicRentalSystem_14Days.Forms
             RentalDetailViewModel? selectedRentalDetailForDebug = dgvRentedComics.SelectedRows[0].DataBoundItem as RentalDetailViewModel;
             if (selectedRentalDetailForDebug != null)
             {
-                LogActivity($"DEBUG: SelectedRows[0] - ComicId: {selectedRentalDetailForDebug.ComicId}, Title: {selectedRentalDetailForDebug.ComicTitle}");
+                LogActivity($"偵錯: SelectedRows[0] - ComicId: {selectedRentalDetailForDebug.ComicId}, 書名: {selectedRentalDetailForDebug.ComicTitle}");
             }
             else
             {
-                LogActivity("DEBUG: SelectedRows[0].DataBoundItem is null or not a RentalDetailViewModel.");
+                LogActivity("偵錯: SelectedRows[0].DataBoundItem 為空或不是 RentalDetailViewModel。");
             }
 
             for (int i = 0; i < dgvRentedComics.SelectedRows.Count; i++)
@@ -419,7 +419,7 @@ namespace ComicRentalSystem_14Days.Forms
                 RentalDetailViewModel? rowDetail = dgvRentedComics.SelectedRows[i].DataBoundItem as RentalDetailViewModel;
                 if (rowDetail != null)
                 {
-                    LogActivity($"DEBUG: SelectedRows[{i}] - ComicId: {rowDetail.ComicId}, Title: {rowDetail.ComicTitle}");
+                    LogActivity($"偵錯: SelectedRows[{i}] - ComicId: {rowDetail.ComicId}, 書名: {rowDetail.ComicTitle}");
                 }
             }
         }
@@ -430,12 +430,12 @@ namespace ComicRentalSystem_14Days.Forms
             MessageBox.Show("服務未初始化，無法執行操作。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
-        LogActivity("Return button clicked."); // This log is now after the debug logs, which is fine.
+        LogActivity("歸還按鈕已點擊。"); // This log is now after the debug logs, which is fine.
 
         if (dgvRentedComics.SelectedRows.Count == 0)
         {
             MessageBox.Show("請從下方列表選擇一筆要歸還的租借記錄。", "歸還提示", MessageBoxButtons.OK, MessageBoxIcon.Information);
-            LogActivity("Return action aborted: No record selected from dgvRentedComics.");
+            LogActivity("歸還操作中止: 未從 dgvRentedComics 選取記錄。");
             return;
         }
 
@@ -444,7 +444,7 @@ namespace ComicRentalSystem_14Days.Forms
         if (selectedRentalDetail == null)
         {
             MessageBox.Show("無法獲取選定的租借資料，請重試。", "歸還錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            LogErrorActivity("Return action failed: Selected item in dgvRentedComics is not a valid RentalDetailViewModel or is null.");
+            LogErrorActivity("歸還操作失敗: dgvRentedComics 中的選定項目無效、為空或不是 RentalDetailViewModel。");
             return;
         }
 
@@ -453,7 +453,7 @@ namespace ComicRentalSystem_14Days.Forms
         if (comicFromService == null)
         {
             MessageBox.Show($"漫畫 '{selectedRentalDetail.ComicTitle}' (ID: {selectedRentalDetail.ComicId}) 在系統中已不存在，可能已被刪除。", "歸還錯誤", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-            LogErrorActivity($"Return action failed: Comic '{selectedRentalDetail.ComicTitle}' (ID: {selectedRentalDetail.ComicId}) not found in service layer.");
+            LogErrorActivity($"歸還操作失敗: 在服務層找不到漫畫 '{selectedRentalDetail.ComicTitle}' (ID: {selectedRentalDetail.ComicId})。");
             LoadRentalDetails(); // Or LoadRentalDetails()
             return;
         }
@@ -466,7 +466,7 @@ namespace ComicRentalSystem_14Days.Forms
         if (!comicFromService.IsRented)
         {
             MessageBox.Show($"漫畫 '{comicFromService.Title}' (ID: {comicFromService.Id}) 的狀態已為未租借。", "歸還提示", MessageBoxButtons.OK, MessageBoxIcon.Information);
-            LogActivity($"Return action noted: Comic '{comicFromService.Title}' (ID: {comicFromService.Id}) is already marked as not rented.");
+            LogActivity($"歸還操作註記: 漫畫 '{comicFromService.Title}' (ID: {comicFromService.Id}) 已標記為未租借。");
             LoadRentalDetails(); // Refresh
             return;
         }
@@ -491,20 +491,20 @@ namespace ComicRentalSystem_14Days.Forms
             Member? returningMember = _memberService?.GetMemberById(previouslyRentedByMemberId);
             string returningMemberName = returningMember?.Name ?? $"ID: {previouslyRentedByMemberId}";
 
-            LogActivity($"Comic '{comicFromService.Title}' (ID: {comicFromService.Id}) successfully returned (was rented by member '{returningMemberName}').");
+            LogActivity($"漫畫 '{comicFromService.Title}' (ID: {comicFromService.Id}) 已成功歸還 (由會員 '{returningMemberName}' 租借)。");
             MessageBox.Show($"漫畫 '{comicFromService.Title}' 已成功歸還。", "歸還成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
             LoadRentalDetails(); // Refresh the list
         }
         catch (Exception ex)
         {
-            LogErrorActivity($"Error during return operation for comic ID: {comicFromService.Id}.", ex);
+            LogErrorActivity($"歸還漫畫ID: {comicFromService.Id} 時發生錯誤。", ex);
             MessageBox.Show($"歸還漫畫時發生錯誤: {ex.Message}\n請查看日誌以獲取詳細資訊。", "歸還錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
         }
 
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
-            LogActivity("RentalForm closing. Unsubscribing from service events.");
+            LogActivity("租借表單正在關閉。正在取消訂閱服務事件。");
 
             _reloadService?.Stop();
 

--- a/ComicRentalSystem_14Days/Logging/FileLogger.cs
+++ b/ComicRentalSystem_14Days/Logging/FileLogger.cs
@@ -23,7 +23,7 @@ namespace ComicRentalSystem_14Days.Logging
             }
             catch (Exception ex) // 技術點5: 例外處理
             {
-                Console.WriteLine($"[CRITICAL] Failed to create log directory '{logDirectory}': {ex.Message}");
+                Console.WriteLine($"[嚴重] 無法建立日誌目錄 '{logDirectory}': {ex.Message}");
                 logDirectory = AppDomain.CurrentDomain.BaseDirectory;
             }
             _logFilePath = Path.Combine(logDirectory, logFileName);
@@ -33,7 +33,7 @@ namespace ComicRentalSystem_14Days.Logging
         // 技術點4: 多型 (當透過 ILogger 引用呼叫此方法時)
         public void Log(string message)
         {
-            WriteLogEntry("INFO", message);
+            WriteLogEntry("資訊", message);
         }
 
         // 技術點3: 介面 (實作 ILogger 的 Log 過載方法)
@@ -41,7 +41,7 @@ namespace ComicRentalSystem_14Days.Logging
         // 技術點4: 多型 (當透過 ILogger 引用呼叫此方法時)
         public void Log(string message, Exception ex)
         {
-            WriteLogEntry("ERROR", $"{message} - Exception: {ex.ToString()}");
+            WriteLogEntry("錯誤", $"{message} - 例外: {ex.ToString()}");
         }
 
         // 技術點3: 介面 (實作 ILogger 的 LogError 過載方法)
@@ -51,17 +51,17 @@ namespace ComicRentalSystem_14Days.Logging
         {
             if (ex != null)
             {
-                WriteLogEntry("ERROR", $"{message} - Exception: {ex.ToString()}");
+                WriteLogEntry("錯誤", $"{message} - 例外: {ex.ToString()}");
             }
             else
             {
-                WriteLogEntry("ERROR", message);
+                WriteLogEntry("錯誤", message);
             }
         }
 
         public void LogWarning(string message)
         {
-            WriteLogEntry("WARNING", message);
+            WriteLogEntry("警告", message);
         }
 
         private void WriteLogEntry(string level, string message)
@@ -78,11 +78,11 @@ namespace ComicRentalSystem_14Days.Logging
             }
             catch (IOException ioEx)
             {
-                Console.WriteLine($"[FileLogger IO Error] Failed to write to log file '{_logFilePath}': {ioEx.Message}. Original message: {message}");
+                Console.WriteLine($"[檔案記錄器 IO 錯誤] 無法寫入日誌檔案 '{_logFilePath}': {ioEx.Message}。原始訊息: {message}");
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[FileLogger Unexpected Error] Failed to write to log file '{_logFilePath}': {ex.Message}. Original message: {message}");
+                Console.WriteLine($"[檔案記錄器 未預期錯誤] 無法寫入日誌檔案 '{_logFilePath}': {ex.Message}。原始訊息: {message}");
             }
         }
     }

--- a/ComicRentalSystem_14Days/Program.cs
+++ b/ComicRentalSystem_14Days/Program.cs
@@ -22,7 +22,7 @@ namespace ComicRentalSystem_14Days
             ApplicationConfiguration.Initialize();
 
             AppLogger = new FileLogger("ComicRentalSystemLog.txt");
-            AppLogger.Log("Application starting...");
+            AppLogger.Log("應用程式啟動中...");
 
             AppFileHelper = new FileHelper();
             AppReloadService = new ReloadService();
@@ -48,34 +48,34 @@ namespace ComicRentalSystem_14Days
                 else
                 {
                     MessageBox.Show("無法初始化核心服務，應用程式即將關閉。", "嚴重錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    AppLogger?.LogError("Application terminated because core services (Logger, AuthService, ComicService, MemberService, or ReloadService) failed to initialize.");
+                    AppLogger?.LogError("由於核心服務 (Logger、AuthService、ComicService、MemberService 或 ReloadService) 初始化失敗，應用程式已終止。");
                 }
             }
             catch (Exception ex)
             {
-                AppLogger?.LogError("Application terminated due to an unhandled exception in Main.", ex);
+                AppLogger?.LogError("由於 Main 中發生未處理的例外狀況，應用程式已終止。", ex);
                 MessageBox.Show("應用程式發生嚴重錯誤，即將關閉。\n詳情請查看日誌檔案。", "嚴重錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             finally
             {
-                AppLogger?.Log("Application shutting down.");
+                AppLogger?.Log("應用程式關閉中。");
             }
         }
 
         // 技術點5: 例外處理 (全域例外處理)
         private static void Application_ThreadException(object sender, System.Threading.ThreadExceptionEventArgs e)
         {
-            AppLogger?.LogError("Unhandled UI Thread Exception", e.Exception);
+            AppLogger?.LogError("未處理的UI執行緒例外狀況", e.Exception);
             MessageBox.Show($"發生未預期的UI執行緒錯誤: {e.Exception.Message}\n詳情請查看日誌。", "UI 錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
 
         // 技術點5: 例外處理 (全域例外處理)
         private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
-            AppLogger?.LogError("Unhandled Non-UI Thread Exception", e.ExceptionObject as Exception);
+            AppLogger?.LogError("未處理的非UI執行緒例外狀況", e.ExceptionObject as Exception);
             if (e.IsTerminating)
             {
-                AppLogger?.Log("Application is terminating due to an unhandled exception.");
+                AppLogger?.Log("由於發生未處理的例外狀況，應用程式正在終止。");
             }
         }
     }

--- a/ComicRentalSystem_14Days/Services/AuthenticationService.cs
+++ b/ComicRentalSystem_14Days/Services/AuthenticationService.cs
@@ -23,40 +23,40 @@ namespace ComicRentalSystem_14Days.Services
             _fileHelper = fileHelper ?? throw new ArgumentNullException(nameof(fileHelper));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _users = LoadUsers() ?? new List<User>();
-            _logger.Log("AuthenticationService initialized.");
+            _logger.Log("驗證服務已初始化。");
         }
 
         private List<User>? LoadUsers()
         {
             try
             {
-                _logger.Log($"Attempting to load users from {_usersFilePath}");
+                _logger.Log($"正在嘗試從 {_usersFilePath} 載入使用者");
                 string json = _fileHelper.ReadFile(_usersFilePath);
                 if (string.IsNullOrWhiteSpace(json))
                 {
-                    _logger.Log("Users file is empty or not found, returning new list.");
+                    _logger.Log("使用者檔案為空或找不到，返回新列表。");
                     return new List<User>();
                 }
                 var users = JsonSerializer.Deserialize<List<User>>(json);
-                _logger.Log($"Successfully loaded {users?.Count ?? 0} users.");
+                _logger.Log($"成功載入 {users?.Count ?? 0} 位使用者。");
                 return users;
             }
             catch (FileNotFoundException)
             {
-                _logger.Log($"Users file '{_usersFilePath}' not found. A new one will be created on registration.");
+                _logger.Log($"找不到使用者檔案 '{_usersFilePath}'。將在註冊時建立新檔案。");
                 return new List<User>();
             }
             catch (JsonException ex)
             {
-                _logger.LogError($"Critical error: User data file '{_usersFilePath}' is corrupted. Details: {ex.Message}", ex);
+                _logger.LogError($"嚴重錯誤: 使用者資料檔案 '{_usersFilePath}' 已損壞。詳細資訊: {ex.Message}", ex);
                 MessageBox.Show($"使用者資料檔案已損壞，無法載入使用者。應用程式將關閉。\n錯誤詳情: {ex.Message}\n檔案路徑: {_usersFilePath}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                throw new ApplicationException("Failed to load critical user data due to corrupted file.", ex);
+                throw new ApplicationException("由於檔案損壞，無法載入關鍵使用者資料。", ex);
             }
             catch (Exception ex)
             {
-                _logger.LogError($"An unexpected error occurred while loading users from {_usersFilePath}. Details: {ex.Message}", ex);
+                _logger.LogError($"從 {_usersFilePath} 載入使用者時發生未預期的錯誤。詳細資訊: {ex.Message}", ex);
                 MessageBox.Show($"載入使用者時發生未預期的錯誤。應用程式將關閉。\n錯誤詳情: {ex.Message}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                throw new ApplicationException("Unexpected error during user data loading.", ex);
+                throw new ApplicationException("載入使用者資料期間發生未預期錯誤。", ex);
             }
         }
 
@@ -64,14 +64,14 @@ namespace ComicRentalSystem_14Days.Services
         {
             try
             {
-                _logger.Log($"Attempting to save {_users.Count} users to {_usersFilePath}");
+                _logger.Log($"正在嘗試將 {_users.Count} 位使用者儲存到 {_usersFilePath}");
                 string json = JsonSerializer.Serialize(_users, new JsonSerializerOptions { WriteIndented = true });
                 _fileHelper.WriteFile(_usersFilePath, json);
-                _logger.Log("Users saved successfully.");
+                _logger.Log("使用者儲存成功。");
             }
             catch (Exception ex)
             {
-                _logger.LogError($"Error saving users to {_usersFilePath}.", ex);
+                _logger.LogError($"將使用者儲存到 {_usersFilePath} 時發生錯誤。", ex);
                 // Handle exception (e.g., notify admin, retry logic)
             }
         }
@@ -92,10 +92,10 @@ namespace ComicRentalSystem_14Days.Services
 
         public bool Register(string username, string password, UserRole role)
         {
-            _logger.Log($"Attempting to register user: {username}, Role: {role}");
+            _logger.Log($"正在嘗試註冊使用者: {username}, 角色: {role}");
             if (_users.Any(u => u.Username.Equals(username, StringComparison.OrdinalIgnoreCase)))
             {
-                _logger.Log($"Registration failed: Username '{username}' already exists.");
+                _logger.Log($"註冊失敗: 使用者名稱 '{username}' 已存在。");
                 return false; // Username already exists
             }
 
@@ -103,24 +103,24 @@ namespace ComicRentalSystem_14Days.Services
             User newUser = new User(username, passwordHash, role);
             _users.Add(newUser);
             SaveUsers();
-            _logger.Log($"User '{username}' registered successfully with ID {newUser.Id}.");
+            _logger.Log($"使用者 '{username}' (ID: {newUser.Id}) 註冊成功。");
             return true;
         }
 
         public User? Login(string username, string password)
         {
-            _logger.Log($"Attempting to login user: {username}");
+            _logger.Log($"正在嘗試登入使用者: {username}");
             string passwordHash = HashPassword(password);
             User? user = _users.FirstOrDefault(u => u.Username.Equals(username, StringComparison.OrdinalIgnoreCase) && u.PasswordHash == passwordHash);
 
             if (user != null)
             {
-                _logger.Log($"User '{username}' logged in successfully. Role: {user.Role}");
+                _logger.Log($"使用者 '{username}' 成功登入。角色: {user.Role}");
                 return user;
             }
             else
             {
-                _logger.Log($"Login failed for user: {username}. Invalid username or password.");
+                _logger.Log($"使用者 '{username}' 登入失敗。使用者名稱或密碼無效。");
                 return null;
             }
         }
@@ -130,30 +130,30 @@ namespace ComicRentalSystem_14Days.Services
         {
             if (!_users.Any(u => u.Role == UserRole.Admin))
             {
-                _logger.Log($"No admin user found. Creating default admin: {adminUsername}");
+                _logger.Log($"找不到管理員使用者。正在建立預設管理員: {adminUsername}");
                 Register(adminUsername, adminPassword, UserRole.Admin);
             }
             else
             {
-                _logger.Log("Admin user already exists.");
+                _logger.Log("管理員使用者已存在。");
             }
         }
 
         public bool DeleteUser(string username)
         {
-            _logger.Log($"Attempting to delete user: {username}");
+            _logger.Log($"正在嘗試刪除使用者: {username}");
             User? userToDelete = _users.FirstOrDefault(u => u.Username.Equals(username, StringComparison.OrdinalIgnoreCase));
 
             if (userToDelete != null)
             {
                 _users.Remove(userToDelete);
                 SaveUsers();
-                _logger.Log($"User '{username}' deleted successfully.");
+                _logger.Log($"使用者 '{username}' 刪除成功。");
                 return true;
             }
             else
             {
-                _logger.Log($"Delete failed: User '{username}' not found.");
+                _logger.Log($"刪除失敗: 找不到使用者 '{username}'。");
                 return false;
             }
         }

--- a/ComicRentalSystem_14Days/Services/ComicService.cs
+++ b/ComicRentalSystem_14Days/Services/ComicService.cs
@@ -28,48 +28,48 @@ namespace ComicRentalSystem_14Days.Services
         public ComicService(IFileHelper fileHelper, ILogger? logger) // Changed parameter to IFileHelper
         {
             _fileHelper = fileHelper ?? throw new ArgumentNullException(nameof(fileHelper));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger), "Logger cannot be null for ComicService.");
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger), "ComicService 的記錄器不可為空。");
 
-            _logger.Log("ComicService initializing.");
+            _logger.Log("ComicService 初始化中。");
 
             LoadComics();
-            _logger.Log($"ComicService initialized. Loaded {_comics.Count} comics.");
+            _logger.Log($"ComicService 初始化完成。已載入 {_comics.Count} 本漫畫。");
         }
 
         private void LoadComics()
         {
-            _logger.Log($"Attempting to load comics from file: '{_comicFileName}'.");
+            _logger.Log($"正在嘗試從檔案載入漫畫: '{_comicFileName}'。");
             try
             {
                 _comics = _fileHelper.ReadFile<Comic>(_comicFileName, Comic.FromCsvString);
-                _logger.Log($"Successfully loaded {_comics.Count} comics from '{_comicFileName}'.");
+                _logger.Log($"成功從 '{_comicFileName}' 載入 {_comics.Count} 本漫畫。");
             }
             catch (Exception ex) when (ex is FormatException || ex is IOException)
             {
-                _logger.LogError($"Critical error: Comic data file '{_comicFileName}' is corrupted or unreadable. Details: {ex.Message}", ex);
+                _logger.LogError($"嚴重錯誤: 漫畫資料檔案 '{_comicFileName}' 已損壞或無法讀取。詳細資訊: {ex.Message}", ex);
                 MessageBox.Show($"漫畫資料檔案已損壞或無法讀取，無法載入漫畫資料庫。應用程式相關功能可能無法正常運作。\n錯誤詳情: {ex.Message}\n檔案路徑: {_comicFileName}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                throw new ApplicationException($"Failed to load comic data from '{_comicFileName}'. Application may not function correctly.", ex);
+                throw new ApplicationException($"無法從 '{_comicFileName}' 載入漫畫資料。應用程式可能無法正常運作。", ex);
             }
             catch (Exception ex)
             {
-                _logger.LogError($"An unexpected error occurred while loading comics from {_comicFileName}. Details: {ex.Message}", ex);
+                _logger.LogError($"從 {_comicFileName} 載入漫畫時發生未預期的錯誤。詳細資訊: {ex.Message}", ex);
                 MessageBox.Show($"載入漫畫資料時發生未預期的錯誤。應用程式相關功能可能無法正常運作。\n錯誤詳情: {ex.Message}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                throw new ApplicationException("Unexpected error during comic data loading.", ex);
+                throw new ApplicationException("載入漫畫資料期間發生未預期錯誤。", ex);
             }
         }
 
         private void SaveComics()
         {
-            _logger.Log($"Attempting to save {_comics.Count} comics to file: '{_comicFileName}'.");
+            _logger.Log($"正在嘗試將 {_comics.Count} 本漫畫儲存到檔案: '{_comicFileName}'。");
             try
             {
                 _fileHelper.WriteFile<Comic>(_comicFileName, _comics, comic => comic.ToCsvString());
-                _logger.Log($"Successfully saved {_comics.Count} comics to '{_comicFileName}'.");
+                _logger.Log($"已成功將 {_comics.Count} 本漫畫儲存到 '{_comicFileName}'。");
                 OnComicsChanged();
             }
             catch (Exception ex)
             {
-                _logger.LogError($"Error saving comics to '{_comicFileName}'.", ex);
+                _logger.LogError($"將漫畫儲存到 '{_comicFileName}' 時發生錯誤。", ex);
                 throw;
             }
         }
@@ -77,25 +77,25 @@ namespace ComicRentalSystem_14Days.Services
         protected virtual void OnComicsChanged()
         {
             ComicsChanged?.Invoke(this, EventArgs.Empty);
-            _logger.Log("ComicsChanged event invoked.");
+            _logger.Log("已觸發 ComicsChanged 事件。");
         }
         public List<Comic> GetAllComics()
         {
-            _logger.Log("GetAllComics called.");
+            _logger.Log("已呼叫 GetAllComics。");
             return _comics;
         }
 
         public Comic? GetComicById(int id)
         {
-            _logger.Log($"GetComicById called for ID: {id}.");
+            _logger.Log($"已為ID: {id} 呼叫 GetComicById。");
             Comic? comic = _comics.FirstOrDefault(c => c.Id == id);
             if (comic == null)
             {
-                _logger.Log($"Comic with ID: {id} not found.");
+                _logger.Log($"找不到ID為: {id} 的漫畫。");
             }
             else
             {
-                _logger.Log($"Comic with ID: {id} found: Title='{comic.Title}'.");
+                _logger.Log($"找到ID為: {id} 的漫畫: 書名='{comic.Title}'。");
             }
             return comic;
         }
@@ -105,32 +105,32 @@ namespace ComicRentalSystem_14Days.Services
             if (comic == null)
             {
                 var ex = new ArgumentNullException(nameof(comic));
-                _logger.LogError("Attempted to add a null comic object.", ex);
+                _logger.LogError("嘗試新增空的漫畫物件。", ex);
                 throw ex;
             }
 
-            _logger.Log($"Attempting to add new comic: Title='{comic.Title}', Author='{comic.Author}'.");
+            _logger.Log($"正在嘗試新增漫畫: 書名='{comic.Title}', 作者='{comic.Author}'。");
 
             if (comic.Id != 0 && _comics.Any(c => c.Id == comic.Id))
             {
-                var ex = new InvalidOperationException($"Comic with ID {comic.Id} already exists.");
-                _logger.LogError($"Failed to add comic: ID {comic.Id} (Title='{comic.Title}') already exists.", ex);
+                var ex = new InvalidOperationException($"ID為 {comic.Id} 的漫畫已存在。");
+                _logger.LogError($"新增漫畫失敗: ID {comic.Id} (書名='{comic.Title}') 已存在。", ex);
                 throw ex;
             }
             if (_comics.Any(c => c.Title.Equals(comic.Title, StringComparison.OrdinalIgnoreCase) &&
                                  c.Author.Equals(comic.Author, StringComparison.OrdinalIgnoreCase)))
             {
-                _logger.LogWarning($"A comic with the same title='{comic.Title}' and author='{comic.Author}' already exists. Proceeding with addition.");
+                _logger.LogWarning($"書名='{comic.Title}' 且作者='{comic.Author}' 相同的漫畫已存在。繼續新增。");
             }
 
             if (comic.Id == 0)
             {
                 comic.Id = GetNextId();
-                _logger.Log($"Generated new ID {comic.Id} for comic '{comic.Title}'.");
+                _logger.Log($"已為漫畫 '{comic.Title}' 產生新的ID {comic.Id}。");
             }
 
             _comics.Add(comic);
-            _logger.Log($"Comic '{comic.Title}' (ID: {comic.Id}) added to in-memory list. Total comics: {_comics.Count}.");
+            _logger.Log($"漫畫 '{comic.Title}' (ID: {comic.Id}) 已新增至記憶體列表。漫畫總數: {_comics.Count}。");
             SaveComics();
         }
 
@@ -139,17 +139,17 @@ namespace ComicRentalSystem_14Days.Services
             if (comic == null)
             {
                 var ex = new ArgumentNullException(nameof(comic));
-                _logger.LogError("Attempted to update with a null comic object.", ex);
+                _logger.LogError("嘗試使用空的漫畫物件進行更新。", ex);
                 throw ex;
             }
 
-            _logger.Log($"Attempting to update comic with ID: {comic.Id} (Title='{comic.Title}').");
+            _logger.Log($"正在嘗試更新ID為: {comic.Id} (書名='{comic.Title}') 的漫畫。");
 
             Comic? existingComic = _comics.FirstOrDefault(c => c.Id == comic.Id);
             if (existingComic == null)
             {
-                var ex = new InvalidOperationException($"Comic with ID {comic.Id} not found for update.");
-                _logger.LogError($"Failed to update comic: ID {comic.Id} (Title='{comic.Title}') not found.", ex);
+                var ex = new InvalidOperationException($"找不到ID為 {comic.Id} 的漫畫進行更新。");
+                _logger.LogError($"更新漫畫失敗: 找不到ID {comic.Id} (書名='{comic.Title}')。", ex);
                 throw ex;
             }
 
@@ -159,39 +159,39 @@ namespace ComicRentalSystem_14Days.Services
             existingComic.Genre = comic.Genre;
             existingComic.IsRented = comic.IsRented;
             existingComic.RentedToMemberId = comic.RentedToMemberId;
-            _logger.Log($"Comic properties for ID {comic.Id} (Title='{existingComic.Title}') updated in-memory.");
+            _logger.Log($"ID {comic.Id} (書名='{existingComic.Title}') 的漫畫屬性已在記憶體中更新。");
 
             SaveComics();
-            _logger.Log($"Comic with ID: {comic.Id} (Title='{existingComic.Title}') update persisted to file.");
+            _logger.Log($"ID為: {comic.Id} (書名='{existingComic.Title}') 的漫畫更新已保存到檔案。");
         }
 
         public void DeleteComic(int id)
         {
-            _logger.Log($"Attempting to delete comic with ID: {id}.");
+            _logger.Log($"正在嘗試刪除ID為: {id} 的漫畫。");
             Comic? comicToRemove = _comics.FirstOrDefault(c => c.Id == id);
 
             if (comicToRemove == null)
             {
-                var ex = new InvalidOperationException($"Comic with ID {id} not found for deletion.");
-                _logger.LogError($"Failed to delete comic: ID {id} not found.", ex);
+                var ex = new InvalidOperationException($"找不到ID為 {id} 的漫畫進行刪除。");
+                _logger.LogError($"刪除漫畫失敗: 找不到ID {id}。", ex);
                 throw ex;
             }
 
             if (comicToRemove.IsRented)
             {
-                _logger.LogWarning($"Attempt to delete rented comic ID {id} ('{comicToRemove.Title}') prevented. Rented by Member ID: {comicToRemove.RentedToMemberId}.");
-                throw new InvalidOperationException("Cannot delete comic: Comic is currently rented.");
+                _logger.LogWarning($"已阻止刪除已租借的漫畫ID {id} ('{comicToRemove.Title}')。由會員ID: {comicToRemove.RentedToMemberId} 租借。");
+                throw new InvalidOperationException("無法刪除漫畫: 漫畫目前已租借。");
             }
 
             _comics.Remove(comicToRemove);
-            _logger.Log($"Comic '{comicToRemove.Title}' (ID: {id}) removed from in-memory list. Total comics: {_comics.Count}.");
+            _logger.Log($"漫畫 '{comicToRemove.Title}' (ID: {id}) 已從記憶體列表移除。漫畫總數: {_comics.Count}。");
             SaveComics();
         }
 
         public int GetNextId()
         {
             int nextId = !_comics.Any() ? 1 : _comics.Max(c => c.Id) + 1;
-            _logger.Log($"Next available comic ID determined as: {nextId}.");
+            _logger.Log($"下一個可用的漫畫ID已確定為: {nextId}。");
             return nextId;
         }
 
@@ -199,41 +199,41 @@ namespace ComicRentalSystem_14Days.Services
         {
             if (string.IsNullOrWhiteSpace(genreFilter))
             {
-                _logger.Log("GetComicsByGenre called with empty genre filter, returning all comics.");
+                _logger.Log("已呼叫 GetComicsByGenre，類型過濾器為空，返回所有漫畫。");
                 return new List<Comic>(_comics);
             }
             else
             {
-                _logger.Log($"GetComicsByGenre called, filtering by genre: '{genreFilter}'.");
+                _logger.Log($"已呼叫 GetComicsByGenre，依類型篩選: '{genreFilter}'。");
                 List<Comic> filteredComics = _comics.Where(c => c.Genre.Equals(genreFilter, StringComparison.OrdinalIgnoreCase)).ToList();
-                _logger.Log($"Found {filteredComics.Count} comics with genre '{genreFilter}'.");
+                _logger.Log($"找到 {filteredComics.Count} 本類型為 '{genreFilter}' 的漫畫。");
                 return filteredComics;
             }
         }
 
         public List<Comic> SearchComics(string? titleFilter = null, string? authorFilter = null)
         {
-            _logger.Log($"SearchComics called with TitleFilter: '{titleFilter ?? "N/A"}', AuthorFilter: '{authorFilter ?? "N/A"}'.");
+            _logger.Log($"已呼叫 SearchComics，書名過濾器: '{titleFilter ?? "N/A"}', 作者過濾器: '{authorFilter ?? "N/A"}'。");
             var query = _comics.AsQueryable();
 
             if (!string.IsNullOrWhiteSpace(titleFilter))
             {
                 query = query.Where(c => c.Title.IndexOf(titleFilter, StringComparison.OrdinalIgnoreCase) >= 0);
-                _logger.Log($"Applied title filter: '{titleFilter}'.");
+                _logger.Log($"已套用書名過濾器: '{titleFilter}'。");
             }
             if (!string.IsNullOrWhiteSpace(authorFilter))
             {
                 query = query.Where(c => c.Author.IndexOf(authorFilter, StringComparison.OrdinalIgnoreCase) >= 0);
-                _logger.Log($"Applied author filter: '{authorFilter}'.");
+                _logger.Log($"已套用作者過濾器: '{authorFilter}'。");
             }
 
             if (string.IsNullOrWhiteSpace(titleFilter) && string.IsNullOrWhiteSpace(authorFilter))
             {
-                _logger.Log("No search filters applied, returning all comics.");
+                _logger.Log("未套用任何搜尋過濾器，返回所有漫畫。");
             }
 
             List<Comic> results = query.ToList();
-            _logger.Log($"SearchComics found {results.Count} matching comics.");
+            _logger.Log($"SearchComics 找到 {results.Count} 本相符的漫畫。");
             return results;
         }
     }

--- a/ComicRentalSystem_14Days/Services/MemberService.cs
+++ b/ComicRentalSystem_14Days/Services/MemberService.cs
@@ -24,56 +24,56 @@ namespace ComicRentalSystem_14Days.Services
         public MemberService(IFileHelper fileHelper, ILogger? logger, ComicService comicService) // Changed parameter to IFileHelper
         {
             _fileHelper = fileHelper ?? throw new ArgumentNullException(nameof(fileHelper));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger), "Logger cannot be null for MemberService.");
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger), "MemberService 的記錄器不可為空。");
             _comicService = comicService ?? throw new ArgumentNullException(nameof(comicService)); // Initialize ComicService
 
-            _logger.Log("MemberService initializing.");
+            _logger.Log("MemberService 初始化中。");
 
             LoadMembers();
-            _logger.Log($"MemberService initialized. Loaded {_members.Count} members.");
+            _logger.Log($"MemberService 初始化完成。已載入 {_members.Count} 位會員。");
         }
 
         public void Reload()
         {
-            _logger.Log("Reload called on MemberService.");
+            _logger.Log("已在 MemberService 上呼叫 Reload。");
             LoadMembers();
             OnMembersChanged();
         }
 
         private void LoadMembers()
         {
-            _logger.Log($"Attempting to load members from file: '{_memberFileName}'.");
+            _logger.Log($"正在嘗試從檔案載入會員: '{_memberFileName}'。");
             try
             {
                 _members = _fileHelper.ReadFile<Member>(_memberFileName, Member.FromCsvString);
-                _logger.Log($"Successfully loaded {_members.Count} members from '{_memberFileName}'.");
+                _logger.Log($"成功從 '{_memberFileName}' 載入 {_members.Count} 位會員。");
             }
             catch (Exception ex) when (ex is FormatException || ex is IOException)
             {
-                _logger.LogError($"Critical error: Member data file '{_memberFileName}' is corrupted or unreadable. Details: {ex.Message}", ex);
+                _logger.LogError($"嚴重錯誤: 會員資料檔案 '{_memberFileName}' 已損壞或無法讀取。詳細資訊: {ex.Message}", ex);
                 MessageBox.Show($"會員資料檔案已損壞或無法讀取，無法載入會員資料庫。應用程式相關功能可能無法正常運作。\n錯誤詳情: {ex.Message}\n檔案路徑: {_memberFileName}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                throw new ApplicationException($"Failed to load member data from '{_memberFileName}'. Application may not function correctly.", ex);
+                throw new ApplicationException($"無法從 '{_memberFileName}' 載入會員資料。應用程式可能無法正常運作。", ex);
             }
             catch (Exception ex)
             {
-                _logger.LogError($"An unexpected error occurred while loading members from {_memberFileName}. Details: {ex.Message}", ex);
+                _logger.LogError($"從 {_memberFileName} 載入會員時發生未預期的錯誤。詳細資訊: {ex.Message}", ex);
                 MessageBox.Show($"載入會員資料時發生未預期的錯誤。應用程式相關功能可能無法正常運作。\n錯誤詳情: {ex.Message}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                throw new ApplicationException("Unexpected error during member data loading.", ex);
+                throw new ApplicationException("載入會員資料期間發生未預期錯誤。", ex);
             }
         }
 
         private void SaveMembers()
         {
-            _logger.Log($"Attempting to save {_members.Count} members to file: '{_memberFileName}'.");
+            _logger.Log($"正在嘗試將 {_members.Count} 位會員儲存到檔案: '{_memberFileName}'。");
             try
             {
                 _fileHelper.WriteFile<Member>(_memberFileName, _members, member => member.ToCsvString());
-                _logger.Log($"Successfully saved {_members.Count} members to '{_memberFileName}'.");
+                _logger.Log($"已成功將 {_members.Count} 位會員儲存到 '{_memberFileName}'。");
                 OnMembersChanged();
             }
             catch (Exception ex)
             {
-                _logger.LogError($"Error saving members to '{_memberFileName}'.", ex);
+                _logger.LogError($"將會員儲存到 '{_memberFileName}' 時發生錯誤。", ex);
                 throw;
             }
         }
@@ -81,26 +81,26 @@ namespace ComicRentalSystem_14Days.Services
         protected virtual void OnMembersChanged()
         {
             MembersChanged?.Invoke(this, EventArgs.Empty);
-            _logger.Log("MembersChanged event invoked.");
+            _logger.Log("已觸發 MembersChanged 事件。");
         }
 
         public List<Member> GetAllMembers()
         {
-            _logger.Log("GetAllMembers called.");
+            _logger.Log("已呼叫 GetAllMembers。");
             return new List<Member>(_members);
         }
 
         public Member? GetMemberById(int id)
         {
-            _logger.Log($"GetMemberById called for ID: {id}.");
+            _logger.Log($"已為ID: {id} 呼叫 GetMemberById。");
             Member? member = _members.FirstOrDefault(m => m.Id == id);
             if (member == null)
             {
-                _logger.Log($"Member with ID: {id} not found.");
+                _logger.Log($"找不到ID為: {id} 的會員。");
             }
             else
             {
-                _logger.Log($"Member with ID: {id} found: Name='{member.Name}'.");
+                _logger.Log($"找到ID為: {id} 的會員: 姓名='{member.Name}'。");
             }
             return member;
         }
@@ -110,31 +110,31 @@ namespace ComicRentalSystem_14Days.Services
             if (member == null)
             {
                 var ex = new ArgumentNullException(nameof(member));
-                _logger.LogError("Attempted to add a null member object.", ex);
+                _logger.LogError("嘗試新增空的會員物件。", ex);
                 throw ex;
             }
 
-            _logger.Log($"Attempting to add new member: Name='{member.Name}', PhoneNumber='{member.PhoneNumber}'.");
+            _logger.Log($"正在嘗試新增會員: 姓名='{member.Name}', 電話號碼='{member.PhoneNumber}'。");
 
             if (member.Id != 0 && _members.Any(m => m.Id == member.Id))
             {
-                var ex = new InvalidOperationException($"Member with ID {member.Id} already exists.");
-                _logger.LogError($"Failed to add member: ID {member.Id} (Name='{member.Name}') already exists.", ex);
+                var ex = new InvalidOperationException($"ID為 {member.Id} 的會員已存在。");
+                _logger.LogError($"新增會員失敗: ID {member.Id} (姓名='{member.Name}') 已存在。", ex);
                 throw ex;
             }
             if (_members.Any(m => m.PhoneNumber == member.PhoneNumber))
             {
-                _logger.LogWarning($"A member with the same phone number '{member.PhoneNumber}' already exists (Name='{_members.First(m => m.PhoneNumber == member.PhoneNumber).Name}'). Proceeding with addition.");
+                _logger.LogWarning($"電話號碼為 '{member.PhoneNumber}' 的會員已存在 (姓名='{_members.First(m => m.PhoneNumber == member.PhoneNumber).Name}')。繼續新增。");
             }
 
             if (member.Id == 0)
             {
                 member.Id = GetNextId();
-                _logger.Log($"Generated new ID {member.Id} for member '{member.Name}'.");
+                _logger.Log($"已為會員 '{member.Name}' 產生新的ID {member.Id}。");
             }
 
             _members.Add(member);
-            _logger.Log($"Member '{member.Name}' (ID: {member.Id}) added to in-memory list. Total members: {_members.Count}.");
+            _logger.Log($"會員 '{member.Name}' (ID: {member.Id}) 已新增至記憶體列表。會員總數: {_members.Count}。");
             SaveMembers();
         }
 
@@ -143,37 +143,37 @@ namespace ComicRentalSystem_14Days.Services
             if (member == null)
             {
                 var ex = new ArgumentNullException(nameof(member));
-                _logger.LogError("Attempted to update with a null member object.", ex);
+                _logger.LogError("嘗試使用空的會員物件進行更新。", ex);
                 throw ex;
             }
 
-            _logger.Log($"Attempting to update member with ID: {member.Id} (Name='{member.Name}').");
+            _logger.Log($"正在嘗試更新ID為: {member.Id} (姓名='{member.Name}') 的會員。");
 
             Member? existingMember = _members.FirstOrDefault(m => m.Id == member.Id);
             if (existingMember == null)
             {
-                var ex = new InvalidOperationException($"Member with ID {member.Id} not found for update.");
-                _logger.LogError($"Failed to update member: ID {member.Id} (Name='{member.Name}') not found.", ex);
+                var ex = new InvalidOperationException($"找不到ID為 {member.Id} 的會員進行更新。");
+                _logger.LogError($"更新會員失敗: 找不到ID {member.Id} (姓名='{member.Name}')。", ex);
                 throw ex;
             }
 
             existingMember.Name = member.Name;
             existingMember.PhoneNumber = member.PhoneNumber;
-            _logger.Log($"Member properties for ID {member.Id} (Name='{existingMember.Name}') updated in-memory.");
+            _logger.Log($"ID {member.Id} (姓名='{existingMember.Name}') 的會員屬性已在記憶體中更新。");
 
             SaveMembers();
-            _logger.Log($"Member with ID: {member.Id} (Name='{existingMember.Name}') update persisted to file.");
+            _logger.Log($"ID為: {member.Id} (姓名='{existingMember.Name}') 的會員更新已保存到檔案。");
         }
 
         public void DeleteMember(int id)
         {
-            _logger.Log($"Attempting to delete member with ID: {id}.");
+            _logger.Log($"正在嘗試刪除ID為: {id} 的會員。");
             Member? memberToRemove = _members.FirstOrDefault(m => m.Id == id);
 
             if (memberToRemove == null)
             {
-                var ex = new InvalidOperationException($"Member with ID {id} not found for deletion.");
-                _logger.LogError($"Failed to delete member: ID {id} not found.", ex);
+                var ex = new InvalidOperationException($"找不到ID為 {id} 的會員進行刪除。");
+                _logger.LogError($"刪除會員失敗: 找不到ID {id}。", ex);
                 throw ex;
             }
 
@@ -181,19 +181,19 @@ namespace ComicRentalSystem_14Days.Services
             var allComics = _comicService.GetAllComics();
             if (allComics.Any(c => c.IsRented && c.RentedToMemberId == id))
             {
-                _logger.LogWarning($"Attempt to delete member ID {id} ('{memberToRemove.Name}') with active rentals prevented.");
-                throw new InvalidOperationException("Cannot delete member: Member has active comic rentals.");
+                _logger.LogWarning($"已阻止刪除擁有有效租借紀錄的會員ID {id} ('{memberToRemove.Name}')。");
+                throw new InvalidOperationException("無法刪除會員: 會員擁有有效的漫畫租借紀錄。");
             }
 
             _members.Remove(memberToRemove);
-            _logger.Log($"Member '{memberToRemove.Name}' (ID: {id}) removed from in-memory list. Total members: {_members.Count}.");
+            _logger.Log($"會員 '{memberToRemove.Name}' (ID: {id}) 已從記憶體列表移除。會員總數: {_members.Count}。");
             SaveMembers();
         }
 
         public int GetNextId()
         {
             int nextId = !_members.Any() ? 1 : _members.Max(m => m.Id) + 1;
-            _logger.Log($"Next available member ID determined as: {nextId}.");
+            _logger.Log($"下一個可用的會員ID已確定為: {nextId}。");
             return nextId;
         }
 
@@ -201,18 +201,18 @@ namespace ComicRentalSystem_14Days.Services
         {
             if (string.IsNullOrWhiteSpace(name))
             {
-                _logger.Log("GetMemberByName called with empty name.");
+                _logger.Log("已呼叫 GetMemberByName，姓名為空。");
                 return null;
             }
-            _logger.Log($"GetMemberByName called for name: '{name}'.");
+            _logger.Log($"已為姓名: '{name}' 呼叫 GetMemberByName。");
             Member? member = _members.FirstOrDefault(m => m.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
             if (member == null)
             {
-                _logger.Log($"Member with name: '{name}' not found.");
+                _logger.Log($"找不到姓名為: '{name}' 的會員。");
             }
             else
             {
-                _logger.Log($"Member with name: '{name}' found: ID='{member.Id}'.");
+                _logger.Log($"找到姓名為: '{name}' 的會員: ID='{member.Id}'。");
             }
             return member;
         }
@@ -221,18 +221,18 @@ namespace ComicRentalSystem_14Days.Services
         {
             if (string.IsNullOrWhiteSpace(phoneNumber))
             {
-                _logger.Log("GetMemberByPhoneNumber called with empty phone number.");
+                _logger.Log("已呼叫 GetMemberByPhoneNumber，電話號碼為空。");
                 return null;
             }
-            _logger.Log($"GetMemberByPhoneNumber called for phone number: '{phoneNumber}'.");
+            _logger.Log($"已為電話號碼: '{phoneNumber}' 呼叫 GetMemberByPhoneNumber。");
             Member? member = _members.FirstOrDefault(m => m.PhoneNumber.Equals(phoneNumber));
             if (member == null)
             {
-                _logger.Log($"Member with phone number: '{phoneNumber}' not found.");
+                _logger.Log($"找不到電話號碼為: '{phoneNumber}' 的會員。");
             }
             else
             {
-                _logger.Log($"Member with phone number: '{phoneNumber}' found: ID='{member.Id}', Name='{member.Name}'.");
+                _logger.Log($"找到電話號碼為: '{phoneNumber}' 的會員: ID='{member.Id}', 姓名='{member.Name}'。");
             }
             return member;
         }
@@ -241,7 +241,7 @@ namespace ComicRentalSystem_14Days.Services
         {
             if (string.IsNullOrWhiteSpace(username))
             {
-                _logger.LogWarning("GetMemberByUsername called with null or empty username.");
+                _logger.LogWarning("已呼叫 GetMemberByUsername，使用者名稱為空或空白。");
                 return null;
             }
 
@@ -250,7 +250,7 @@ namespace ComicRentalSystem_14Days.Services
 
             if (allMembers == null || !allMembers.Any())
             {
-                _logger.LogWarning("GetMemberByUsername: No members available to search.");
+                _logger.LogWarning("GetMemberByUsername: 無可用會員進行搜尋。");
                 return null;
             }
 
@@ -262,11 +262,11 @@ namespace ComicRentalSystem_14Days.Services
 
             if (foundMember != null)
             {
-                _logger.Log($"GetMemberByUsername: Found member with ID {foundMember.Id} for username '{username}'.");
+                _logger.Log($"GetMemberByUsername: 找到ID為 {foundMember.Id} 且使用者名稱為 '{username}' 的會員。");
             }
             else
             {
-                _logger.Log($"GetMemberByUsername: No member found for username '{username}'.");
+                _logger.Log($"GetMemberByUsername: 找不到使用者名稱為 '{username}' 的會員。");
             }
 
             return foundMember;


### PR DESCRIPTION
This commit translates various parts of the Comic Rental System application into Traditional Chinese.

Key areas translated include:
- Log messages across all services, forms, and core program files.
- MessageBox titles and content.
- UI element text (labels, buttons, form titles) in both .cs and .Designer.cs files.
- Exception messages in model parsing logic.
- Internal console messages in helper classes.

The translation covered the following files:
- MainForm.cs
- Forms/ComicEditForm.cs
- Forms/MemberEditForm.cs
- Forms/LoginForm.cs
- Forms/RegistrationForm.cs
- Forms/RentalForm.cs
- Forms/RentalPeriodForm.cs and .Designer.cs
- Services/ComicService.cs
- Services/MemberService.cs
- Services/AuthenticationService.cs
- Logging/FileLogger.cs
- Program.cs
- Models/Comic.cs (exception messages)
- Models/Member.cs (exception messages)
- Helpers/FileHelper.cs (console messages)

Care was taken to ensure consistency in terminology and to preserve string formatting placeholders. This change addresses the issue of localizing the application for Traditional Chinese users.