### PR TITLE
Fix: Address multiple user workflow issues

### DIFF
--- a/ComicRentalSystem_14Days/Forms/MemberEditForm.cs
+++ b/ComicRentalSystem_14Days/Forms/MemberEditForm.cs
@@ -71,7 +71,10 @@ namespace ComicRentalSystem_14Days.Forms
 
             LogActivity("儲存會員按鈕已點擊。");
 
-            if (string.IsNullOrWhiteSpace(txtName.Text))
+            string name = txtName.Text.Trim();
+            string phoneNumber = txtPhoneNumber.Text.Trim();
+
+            if (string.IsNullOrWhiteSpace(name))
             {
                 LogActivity("驗證失敗: 姓名不得為空。");
                 MessageBox.Show("姓名不得為空。", "驗證錯誤", MessageBoxButtons.OK, MessageBoxIcon.Warning);
@@ -79,7 +82,15 @@ namespace ComicRentalSystem_14Days.Forms
                 return;
             }
 
-            if (string.IsNullOrWhiteSpace(txtPhoneNumber.Text))
+            if (!name.All(c => char.IsLetter(c) || char.IsWhiteSpace(c)))
+            {
+                LogActivity("驗證失敗: 姓名包含無效字元。");
+                MessageBox.Show("姓名只能包含字母和空格。", "驗證錯誤", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                txtName.Focus();
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(phoneNumber))
             {
                 LogActivity("驗證失敗: 電話號碼不得為空。");
                 MessageBox.Show("電話號碼不得為空。", "驗證錯誤", MessageBoxButtons.OK, MessageBoxIcon.Warning);
@@ -87,10 +98,18 @@ namespace ComicRentalSystem_14Days.Forms
                 return;
             }
 
-            if (!txtPhoneNumber.Text.All(char.IsDigit))
+            if (!phoneNumber.All(char.IsDigit))
             {
                 LogActivity("驗證失敗: 電話號碼包含非數字字元。");
                 MessageBox.Show("電話號碼只能包含數字。", "驗證錯誤", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                txtPhoneNumber.Focus();
+                return;
+            }
+
+            if (phoneNumber.Length < 7 || phoneNumber.Length > 15)
+            {
+                LogActivity("驗證失敗: 電話號碼長度無效。");
+                MessageBox.Show("電話號碼長度應在 7 到 15 位數字之間。", "驗證錯誤", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 txtPhoneNumber.Focus();
                 return;
             }
@@ -100,19 +119,23 @@ namespace ComicRentalSystem_14Days.Forms
                 if (_isEditMode && _editableMember != null)
                 {
                     LogActivity($"正在嘗試儲存現有會員ID: {_editableMember.Id} 的變更。");
-                    _editableMember.Name = txtName.Text.Trim();
-                    _editableMember.PhoneNumber = txtPhoneNumber.Text.Trim();
+                    _editableMember.Name = name;
+                    _editableMember.PhoneNumber = phoneNumber;
                     _memberService.UpdateMember(_editableMember);
                     LogActivity($"會員ID: {_editableMember.Id} 已成功更新。");
                     MessageBox.Show("會員資料已更新。", "成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
                 else
                 {
+                    // This block is less likely to be hit if RegistrationForm is used for all new member additions.
+                    // However, keeping the logic sound in case MemberEditForm is used for adding non-user members directly.
                     LogActivity("正在嘗試新增會員。");
                     Member newMember = new Member
                     {
-                        Name = txtName.Text.Trim(),
-                        PhoneNumber = txtPhoneNumber.Text.Trim()
+                        Name = name,
+                        PhoneNumber = phoneNumber
+                        // Username would typically be set if this member was also a User,
+                        // which is handled by RegistrationForm.
                     };
                     _memberService.AddMember(newMember);
                     LogActivity($"新會員 '{newMember.Name}' (ID: {newMember.Id}) 已成功新增。");

--- a/ComicRentalSystem_14Days/Forms/RegistrationForm.Designer.cs
+++ b/ComicRentalSystem_14Days/Forms/RegistrationForm.Designer.cs
@@ -114,41 +114,61 @@ namespace ComicRentalSystem_14Days.Forms
             // lblName
             //
             this.lblName.AutoSize = true;
-            this.lblName.Location = new System.Drawing.Point(30, 150); // Position where lblRole was
+            this.lblName.Location = new System.Drawing.Point(30, 150);
             this.lblName.Name = "lblName";
             this.lblName.Size = new System.Drawing.Size(39, 15);
-            this.lblName.TabIndex = 6; // Original TabIndex of lblRole
+            this.lblName.TabIndex = 6; // Kept as is, will be re-ordered later if needed by actual designer
             this.lblName.Text = "姓名:";
             //
             // txtName
             //
-            this.txtName.Location = new System.Drawing.Point(130, 147); // Position where cmbRole was
+            this.txtName.Location = new System.Drawing.Point(130, 147);
             this.txtName.Name = "txtName";
             this.txtName.Size = new System.Drawing.Size(200, 23);
-            this.txtName.TabIndex = 7; // Original TabIndex of cmbRole
+            this.txtName.TabIndex = 7; // Kept as is
             //
             // lblPhoneNumber
             //
             this.lblPhoneNumber.AutoSize = true;
-            this.lblPhoneNumber.Location = new System.Drawing.Point(30, 190); // Below Name
+            this.lblPhoneNumber.Location = new System.Drawing.Point(30, 190);
             this.lblPhoneNumber.Name = "lblPhoneNumber";
             this.lblPhoneNumber.Size = new System.Drawing.Size(63, 15);
-            this.lblPhoneNumber.TabIndex = 8; // Next TabIndex
+            this.lblPhoneNumber.TabIndex = 8; // Kept as is
             this.lblPhoneNumber.Text = "電話號碼:";
             //
             // txtPhoneNumber
             //
-            this.txtPhoneNumber.Location = new System.Drawing.Point(130, 187); // Below Name
+            this.txtPhoneNumber.Location = new System.Drawing.Point(130, 187);
             this.txtPhoneNumber.Name = "txtPhoneNumber";
             this.txtPhoneNumber.Size = new System.Drawing.Size(200, 23);
-            this.txtPhoneNumber.TabIndex = 9; // Next TabIndex
+            this.txtPhoneNumber.TabIndex = 9; // Kept as is
+            //
+            // lblRole
+            //
+            this.lblRole.AutoSize = true;
+            this.lblRole.Location = new System.Drawing.Point(30, 227); // Adjusted Y
+            this.lblRole.Name = "lblRole";
+            this.lblRole.Size = new System.Drawing.Size(31, 15);
+            this.lblRole.TabIndex = 10; // New TabIndex
+            this.lblRole.Text = "角色:";
+            this.lblRole.Visible = false;
+            //
+            // cmbRole
+            //
+            this.cmbRole.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbRole.FormattingEnabled = true;
+            this.cmbRole.Location = new System.Drawing.Point(130, 224); // Adjusted Y
+            this.cmbRole.Name = "cmbRole";
+            this.cmbRole.Size = new System.Drawing.Size(200, 23);
+            this.cmbRole.TabIndex = 11; // New TabIndex
+            this.cmbRole.Visible = false;
             //
             // btnRegister
             //
-            this.btnRegister.Location = new System.Drawing.Point(130, 230); // Moved down
+            this.btnRegister.Location = new System.Drawing.Point(130, 267); // Adjusted Y
             this.btnRegister.Name = "btnRegister";
             this.btnRegister.Size = new System.Drawing.Size(100, 30);
-            this.btnRegister.TabIndex = 10; // Next TabIndex
+            this.btnRegister.TabIndex = 12; // New TabIndex
             this.btnRegister.Text = "註冊";
             this.btnRegister.UseVisualStyleBackColor = true;
             this.btnRegister.Click += new System.EventHandler(this.btnRegister_Click);
@@ -157,14 +177,16 @@ namespace ComicRentalSystem_14Days.Forms
             //
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(384, 290); // Adjusted ClientSize
+            this.ClientSize = new System.Drawing.Size(384, 320); // Adjusted ClientSize
             this.Controls.Add(this.btnRegister);
             this.Controls.Add(this.txtPhoneNumber);
             this.Controls.Add(this.lblPhoneNumber);
             this.Controls.Add(this.txtName);
             this.Controls.Add(this.lblName);
-            this.Controls.Add(this.cmbRole);
-            this.Controls.Add(this.lblRole);
+            // cmbRole and lblRole are already in Controls collection from their original declaration
+            // So, ensure they are not added twice. The diff should handle their property changes.
+            // this.Controls.Add(this.cmbRole);  // Already present
+            // this.Controls.Add(this.lblRole); // Already present
             this.Controls.Add(this.txtConfirmPassword);
             this.Controls.Add(this.lblConfirmPassword);
             this.Controls.Add(this.txtPassword);

--- a/ComicRentalSystem_14Days/Services/AuthenticationService.cs
+++ b/ComicRentalSystem_14Days/Services/AuthenticationService.cs
@@ -49,13 +49,13 @@ namespace ComicRentalSystem_14Days.Services
             catch (JsonException ex)
             {
                 _logger.LogError($"嚴重錯誤: 使用者資料檔案 '{_usersFilePath}' 已損壞。詳細資訊: {ex.Message}", ex);
-                MessageBox.Show($"使用者資料檔案已損壞，無法載入使用者。應用程式將關閉。\n錯誤詳情: {ex.Message}\n檔案路徑: {_usersFilePath}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                // MessageBox.Show($"使用者資料檔案已損壞，無法載入使用者。應用程式將關閉。\n錯誤詳情: {ex.Message}\n檔案路徑: {_usersFilePath}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 throw new ApplicationException("由於檔案損壞，無法載入關鍵使用者資料。", ex);
             }
             catch (Exception ex)
             {
                 _logger.LogError($"從 {_usersFilePath} 載入使用者時發生未預期的錯誤。詳細資訊: {ex.Message}", ex);
-                MessageBox.Show($"載入使用者時發生未預期的錯誤。應用程式將關閉。\n錯誤詳情: {ex.Message}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                // MessageBox.Show($"載入使用者時發生未預期的錯誤。應用程式將關閉。\n錯誤詳情: {ex.Message}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 throw new ApplicationException("載入使用者資料期間發生未預期錯誤。", ex);
             }
         }

--- a/ComicRentalSystem_14Days/Services/MemberService.cs
+++ b/ComicRentalSystem_14Days/Services/MemberService.cs
@@ -51,13 +51,13 @@ namespace ComicRentalSystem_14Days.Services
             catch (Exception ex) when (ex is FormatException || ex is IOException)
             {
                 _logger.LogError($"嚴重錯誤: 會員資料檔案 '{_memberFileName}' 已損壞或無法讀取。詳細資訊: {ex.Message}", ex);
-                MessageBox.Show($"會員資料檔案已損壞或無法讀取，無法載入會員資料庫。應用程式相關功能可能無法正常運作。\n錯誤詳情: {ex.Message}\n檔案路徑: {_memberFileName}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                // MessageBox.Show($"會員資料檔案已損壞或無法讀取，無法載入會員資料庫。應用程式相關功能可能無法正常運作。\n錯誤詳情: {ex.Message}\n檔案路徑: {_memberFileName}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 throw new ApplicationException($"無法從 '{_memberFileName}' 載入會員資料。應用程式可能無法正常運作。", ex);
             }
             catch (Exception ex)
             {
                 _logger.LogError($"從 {_memberFileName} 載入會員時發生未預期的錯誤。詳細資訊: {ex.Message}", ex);
-                MessageBox.Show($"載入會員資料時發生未預期的錯誤。應用程式相關功能可能無法正常運作。\n錯誤詳情: {ex.Message}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                // MessageBox.Show($"載入會員資料時發生未預期的錯誤。應用程式相關功能可能無法正常運作。\n錯誤詳情: {ex.Message}", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 throw new ApplicationException("載入會員資料期間發生未預期錯誤。", ex);
             }
         }
@@ -254,10 +254,10 @@ namespace ComicRentalSystem_14Days.Services
                 return null;
             }
 
-            // Assuming Member.Name is the field that corresponds to the username.
+            // Using Member.Username for lookup.
             // Using OrdinalIgnoreCase for case-insensitive matching, which is common for usernames.
             Member? foundMember = allMembers.FirstOrDefault(m =>
-                string.Equals(m.Name, username, StringComparison.OrdinalIgnoreCase)
+                string.Equals(m.Username, username, StringComparison.OrdinalIgnoreCase)
             );
 
             if (foundMember != null)
@@ -270,6 +270,26 @@ namespace ComicRentalSystem_14Days.Services
             }
 
             return foundMember;
+        }
+
+        public List<Member> SearchMembers(string searchTerm)
+        {
+            _logger.Log($"已呼叫 SearchMembers，搜尋詞: '{searchTerm}'。");
+            if (string.IsNullOrWhiteSpace(searchTerm))
+            {
+                return new List<Member>(_members); // Return all if search term is empty
+            }
+
+            var lowerSearchTerm = searchTerm.ToLowerInvariant();
+            List<Member> results = _members.Where(m =>
+                (m.Name != null && m.Name.ToLowerInvariant().Contains(lowerSearchTerm)) ||
+                (m.PhoneNumber != null && m.PhoneNumber.Contains(searchTerm)) || // Phone numbers usually don't need case insensitivity
+                (m.Id.ToString().Equals(searchTerm)) ||
+                (m.Username != null && m.Username.ToLowerInvariant().Contains(lowerSearchTerm)) // Also search by Username
+            ).ToList();
+
+            _logger.Log($"SearchMembers 找到 {results.Count} 位符合條件的會員。");
+            return results;
         }
     }
 }


### PR DESCRIPTION
This commit resolves several user workflow inconsistencies and bugs identified during a review:

1.  **Admin User/Member Creation:**
    - RegistrationForm now allows Admins to select roles (Admin/Member).
    - MemberManagementForm's "Add Member" uses RegistrationForm, ensuring User and Member accounts are created together, and Member.Username is populated.
    - Self-registration via LoginForm defaults to Member role, hiding role selection. (Addresses P1.1, P5.1/P5.2, P1.2)

2.  **Member Lookup:**
    - Corrected MemberService.GetMemberByUsername() to use Member.Username for lookups instead of Member.Name. (Addresses P3.1, P4.7)

3.  **Incomplete Registration Handling:**
    - RegistrationForm now attempts to roll back User creation if Member profile creation fails, preventing orphaned User accounts. (Addresses P1.3, P4.3, P5.4)

4.  **Input Validation:**
    - Added stricter validation for Name (letters/spaces) and Phone Number (digits, length 7-15) in RegistrationForm and MemberEditForm. (Addresses P1.5)

5.  **Admin Comic Rental Status Editing:**
    - ComicEditForm now allows Admins to mark a comic as "returned" (unchecking IsRented), which clears relevant rental fields and sets ActualReturnTime.
    - Prevents Admins from directly marking as "rented" via ComicEditForm, guiding them to RentalForm for data integrity. (Addresses P2.A1)

6.  **Search Functionality in Management Forms:**
    - Added backend logic for search in ComicManagementForm (by Title, Author, ISBN, Genre, ID) and MemberManagementForm (by Name, Phone, ID, Username).
    - UI elements (TextBoxes, Buttons) for search need to be added via the Forms Designer. (Addresses P2.A3, P2.B4)

7.  **Error Messaging for Critical File Loads:**
    - Removed redundant MessageBox calls in service classes for critical file load errors to prevent double error messages. (Addresses P4.1)