### PR TITLE
Fix: Remove duplicate GetAllUsers method in AuthenticationService

### DIFF
--- a/ComicRentalSystem_14Days/Services/AuthenticationService.cs
+++ b/ComicRentalSystem_14Days/Services/AuthenticationService.cs
@@ -149,11 +149,6 @@ namespace ComicRentalSystem_14Days.Services
             return user;
         }
 
-        public List<User> GetAllUsers()
-        {
-            return new List<User>(_users);
-        }
-
         public void SaveUsers() // Changed from private to public
         {
             string backupFilePath = _usersFilePath + ".bak"; // e.g., "users.json.bak"


### PR DESCRIPTION
Resolved CS0111 by deleting a redundant GetAllUsers method in AuthenticationService.cs. This also resolves the associated CS0121 error in ChangeUserRoleForm.cs, which was caused by the ambiguous method call.