### PR TITLE
Fix: Prevent IndexOutOfRangeException in ComicManagementForm DataGrid…

### DIFF
--- a/ComicRentalSystem_14Days/Forms/ComicManagementForm.cs
+++ b/ComicRentalSystem_14Days/Forms/ComicManagementForm.cs
@@ -160,6 +160,7 @@ namespace ComicRentalSystem_14Days.Forms
                 }
 
                 Action updateGrid = () => {
+                    dgvComics.ClearSelection();
                     dgvComics.DataSource = null;
                     dgvComics.DataSource = comics;
                 };
@@ -169,10 +170,56 @@ namespace ComicRentalSystem_14Days.Forms
                     if (dgvComics.InvokeRequired)
                     {
                         dgvComics.Invoke(updateGrid);
+                        if (dgvComics.Rows.Count > 0)
+                        {
+                            int firstVisibleColumnIndex = -1;
+                            foreach (DataGridViewColumn col in dgvComics.Columns)
+                            {
+                                if (col.Visible && col.DisplayIndex >= 0) // Ensure column is visible and has a valid display index
+                                {
+                                    if (firstVisibleColumnIndex == -1 || col.DisplayIndex < dgvComics.Columns[firstVisibleColumnIndex].DisplayIndex)
+                                    {
+                                        firstVisibleColumnIndex = col.Index;
+                                    }
+                                }
+                            }
+                            if (firstVisibleColumnIndex != -1)
+                            {
+                                dgvComics.CurrentCell = dgvComics.Rows[0].Cells[firstVisibleColumnIndex];
+                            }
+                            else // Fallback if no visible columns, though unlikely for a populated grid
+                            {
+                                 // Optional: Log a warning if no visible column is found, though CurrentCell can't be set.
+                                 // Logger?.LogWarning("LoadComicsData: No visible columns found in dgvComics to set CurrentCell.");
+                            }
+                        }
                     }
                     else
                     {
                         updateGrid();
+                        if (dgvComics.Rows.Count > 0)
+                        {
+                            int firstVisibleColumnIndex = -1;
+                            foreach (DataGridViewColumn col in dgvComics.Columns)
+                            {
+                                if (col.Visible && col.DisplayIndex >= 0) // Ensure column is visible and has a valid display index
+                                {
+                                    if (firstVisibleColumnIndex == -1 || col.DisplayIndex < dgvComics.Columns[firstVisibleColumnIndex].DisplayIndex)
+                                    {
+                                        firstVisibleColumnIndex = col.Index;
+                                    }
+                                }
+                            }
+                            if (firstVisibleColumnIndex != -1)
+                            {
+                                dgvComics.CurrentCell = dgvComics.Rows[0].Cells[firstVisibleColumnIndex];
+                            }
+                            else // Fallback if no visible columns, though unlikely for a populated grid
+                            {
+                                 // Optional: Log a warning if no visible column is found, though CurrentCell can't be set.
+                                 // Logger?.LogWarning("LoadComicsData: No visible columns found in dgvComics to set CurrentCell.");
+                            }
+                        }
                     }
                 }
                 LogActivity($"Successfully loaded {comics.Count} comics into DataGridView with search term '{searchTerm}'.");


### PR DESCRIPTION
…View

The DataGridView in ComicManagementForm could throw an IndexOutOfRangeException when refreshing data, particularly after a new comic was added. This was due to the CurrencyManager potentially having an invalid index (-1) during the OnRowEnter event.

This commit addresses the issue by:
1. Clearing the DataGridView's selection (`ClearSelection()`) before its DataSource is set to null during a refresh. This helps prevent issues related to stale selections.
2. Explicitly setting the `CurrentCell` to the first cell of the first visible column in the DataGridView after its DataSource has been updated and if rows are present. This ensures the CurrencyManager is correctly positioned to a valid row, preventing the exception.