### PR TITLE
Fix: Prevent IndexOutOfRangeException in ComicManagementForm

### DIFF
--- a/ComicRentalSystem_14Days/Forms/ComicManagementForm.cs
+++ b/ComicRentalSystem_14Days/Forms/ComicManagementForm.cs
@@ -210,9 +210,9 @@ namespace ComicRentalSystem_14Days.Forms
                                     }
                                 }
                             }
-                            if (firstVisibleColumnIndex != -1)
+    if (firstVisibleColumnIndex != -1 && dgvComics.Rows.Count > 0 && dgvComics.Rows[0].Cells.Count > firstVisibleColumnIndex)
                             {
-                                dgvComics.CurrentCell = dgvComics.Rows[0].Cells[firstVisibleColumnIndex];
+        dgvComics.CurrentCell = dgvComics.Rows[0].Cells[firstVisibleColumnIndex];
                             }
                             else // Fallback if no visible columns, though unlikely for a populated grid
                             {


### PR DESCRIPTION
The `LoadComicsData` method in `ComicManagementForm.cs` could throw an IndexOutOfRangeException when attempting to set `dgvComics.CurrentCell` after the comics list was updated. This typically occurred after you added a new comic, which triggers a refresh of the DataGridView.

Although an initial check for `dgvComics.Rows.Count > 0` existed, the exception (related to `CurrencyManager` and index -1) suggested that the state of the DataGridView or its underlying data source could still lead to issues when accessing `Rows[0]` or `Cells[firstVisibleColumnIndex]`.

This commit adds more robust checks directly before the assignment to `dgvComics.CurrentCell`:
- It re-verifies `dgvComics.Rows.Count > 0`.
- It ensures `firstVisibleColumnIndex` is a valid index for the `Cells` collection of the first row (`dgvComics.Rows[0].Cells.Count > firstVisibleColumnIndex`).

These additional conditions prevent the application from trying to access an invalid row or cell, thus resolving the reported `IndexOutOfRangeException`.