### PR TITLE
Fix: Correct closing brace syntax in Designer.cs files

### DIFF
--- a/ComicRentalSystem_14Days/Forms/ComicEditForm.Designer.cs
+++ b/ComicRentalSystem_14Days/Forms/ComicEditForm.Designer.cs
@@ -222,5 +222,5 @@
         private System.Windows.Forms.Button btnCancel;
         private System.Windows.Forms.GroupBox gbComicDetails;
         private System.Windows.Forms.GroupBox gbStatus;
-    });
+    }
 }

--- a/ComicRentalSystem_14Days/Forms/MemberEditForm.Designer.cs
+++ b/ComicRentalSystem_14Days/Forms/MemberEditForm.Designer.cs
@@ -142,5 +142,5 @@
         private System.Windows.Forms.Button btnSaveMember;
         private System.Windows.Forms.Button btnCancelMember;
         private System.Windows.Forms.GroupBox gbMemberDetails;
-    });
+    }
 }


### PR DESCRIPTION
Ensured that `ComicEditForm.Designer.cs` and `MemberEditForm.Designer.cs` have the correct closing braces for their respective classes and the `ComicRentalSystem_14Days.Forms` namespace.

This resolves issues related to CS1022 (Type or namespace definition, or end-of-file expected) and CS1513 (} expected) errors that were occurring due to malformed file endings, likely caused by an extraneous `});` after the class member declarations.