### PR TITLE
Fix: Comics list incorrect after refresh due to header skip

### DIFF
--- a/ComicRentalSystem_14Days/Services/ComicService.cs
+++ b/ComicRentalSystem_14Days/Services/ComicService.cs
@@ -77,7 +77,7 @@ namespace ComicRentalSystem_14Days.Services
 
                 // Skip header line if present (assuming simple CSV structure)
                 // Adjust Skip count if your CSV has no header or multiple header lines.
-                foreach (var line in lines.Skip(1))
+                foreach (var line in lines)
                 {
                     if (string.IsNullOrWhiteSpace(line)) continue;
                     try


### PR DESCRIPTION
The ComicService's asynchronous reload method (LoadComicsAsync) was incorrectly skipping the first line of the comics.csv file, assuming it was a header row. However, the CSV file is saved without a header. This caused the first comic to be omitted after a refresh, leading to an apparent data loss or the list count being reduced.

This commit removes the `.Skip(1)` call in LoadComicsAsync, ensuring all lines from the CSV are parsed. This makes the asynchronous load behavior consistent with the synchronous load and the file saving mechanism, both of which treat the CSV as headerless data.