### PR TITLE
Fix: Wire up admin navigation buttons in MainForm

### DIFF
--- a/ComicRentalSystem_14Days/MainForm.cs
+++ b/ComicRentalSystem_14Days/MainForm.cs
@@ -922,22 +922,26 @@ namespace ComicRentalSystem_14Days
             else if (selectedButton == btnNavMemberMgmt)
             {
                 // Show Member Management related controls
-                _logger?.Log("Member Management view selected.");
+                // _logger?.Log("Member Management view selected."); // Original logging
+                this.會員管理ToolStripMenuItem_Click(this, EventArgs.Empty);
             }
             else if (selectedButton == btnNavRentalMgmt)
             {
                 // Show Rental Management related controls
-                _logger?.Log("Rental Management view selected.");
+                // _logger?.Log("Rental Management view selected."); // Original logging
+                this.rentalManagementToolStripMenuItem_Click(this, EventArgs.Empty);
             }
             else if (selectedButton == btnNavUserReg)
             {
                 // Show User Registration related controls
-                 _logger?.Log("User Registration view selected.");
+                // _logger?.Log("User Registration view selected."); // Original logging
+                this.使用者註冊ToolStripMenuItem_Click(this, EventArgs.Empty);
             }
             else if (selectedButton == btnNavLogs)
             {
                 // Show Logs related controls
-                 _logger?.Log("Logs view selected.");
+                // _logger?.Log("Logs view selected."); // Original logging
+                this.檢視日誌ToolStripMenuItem_Click(this, EventArgs.Empty);
             }
         }
 


### PR DESCRIPTION
The admin navigation buttons (Member Management, Rental Management, User Registration, Logs) in MainForm.cs were previously only logging their selection.

This commit updates the SelectNavButton method in MainForm.cs to call the corresponding ToolStripMenuItem_Click event handlers when these navigation buttons are clicked. This ensures that clicking these buttons now opens the respective forms (MemberManagementForm, RentalForm, RegistrationForm) or triggers the intended functionality (viewing logs), consistent with the behavior of the menu items.

This change addresses the issue of buttons not having corresponding working functions, making the admin interface more functional and intuitive.