### PR TITLE
Fix: Ensure 'Rent Comic' button is visible for Member users

### DIFF
--- a/ComicRentalSystem_14Days/MainForm.cs
+++ b/ComicRentalSystem_14Days/MainForm.cs
@@ -424,6 +424,13 @@ namespace ComicRentalSystem_14Days
                     // Update text for labels inside tabs for clarity
                     if(lblAvailableComics != null) lblAvailableComics.Text = "Select a comic below to rent:";
                     if(lblMyRentedComicsHeader != null) lblMyRentedComicsHeader.Text = "Your currently rented items:";
+
+                    // ***** START OF CHANGE *****
+                    if (btnRentComic != null)
+                    {
+                        btnRentComic.Visible = true;
+                    }
+                    // ***** END OF CHANGE *****
                 }
                 else
                 {


### PR DESCRIPTION
The 'Rent Comic' button (btnRentComic) was initialized with Visible=false in the designer. This change explicitly sets btnRentComic.Visible = true within the SetupUIAccessControls method when the UI is being configured for a Member user.

This addresses the issue where members reported the button was missing, preventing them from accessing the comic rental functionality.