### PR TITLE
Fix: Ensure My Rentals works for new users and add diagnostics

### DIFF
--- a/ComicRentalSystem_14Days/Models/RentalDetailViewModel.cs
+++ b/ComicRentalSystem_14Days/Models/RentalDetailViewModel.cs
@@ -12,6 +12,7 @@ namespace ComicRentalSystem_14Days.Models
         // Comic Details
         public int ComicId { get; set; }
         public string ComicTitle { get; set; } = string.Empty;
+        public string Author { get; set; } = string.Empty;
 
         // Rental Details
         public DateTime? RentalDate { get; set; }


### PR DESCRIPTION
This commit addresses the issue where "My Rentals" might not display rented comics for general members.

The investigation revealed that the `RegistrationForm` correctly creates `Member` entities with a `Username` that matches the login `User.Username`. This ensures that for new users, the linkage required to display their rented comics in the "My Rentals" tab is correctly established.

The root cause for existing members facing this issue is likely due to data inconsistencies in `members.csv`, where the `Member.Username` field might be missing or might not match the login `User.Username` (potentially due to a previous fallback where `Member.Username` defaulted to `Member.Name`).

Changes in this commit:
- Added detailed logging to `MainForm.LoadMyRentedComics` to help diagnose issues for specific users by tracing member profile retrieval and comic filtering.
- Refactored `MainForm.LoadMyRentedComics` to use `RentalDetailViewModel` instead of an anonymous type, improving code clarity and maintainability. This included adding an `Author` property to `RentalDetailViewModel`.
- Updated `MainForm.SetupMyRentedComicsDataGridView` and `MainForm.dgvMyRentedComics_CellFormatting` to align with the use of `RentalDetailViewModel`.

While these changes improve diagnostics and code quality, and ensure the feature works for new users, resolving the issue for existing users with inconsistent data would require data migration or manual correction of `members.csv`, which is outside the scope of these code modifications.