### PR TITLE
feature/加回Unit Test

### DIFF
--- a/ComicRentalSystem_14Days.Tests/ComicRentalSystem_14Days.Tests.csproj
+++ b/ComicRentalSystem_14Days.Tests/ComicRentalSystem_14Days.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ComicRentalSystem_14Days\ComicRentalSystem_14Days.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ComicRentalSystem_14Days.Tests/ComicServiceTests.cs
+++ b/ComicRentalSystem_14Days.Tests/ComicServiceTests.cs
@@ -1,0 +1,558 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ComicRentalSystem_14Days.Services;
+using ComicRentalSystem_14Days.Models;
+using ComicRentalSystem_14Days.Interfaces;
+using ComicRentalSystem_14Days.Tests.Mocks; // Assuming Mocks are in this namespace
+using System;
+using System.Collections.Generic;
+using System.IO; // For FileNotFoundException
+using System.Linq;
+
+namespace ComicRentalSystem_14Days.Tests
+{
+    [TestClass]
+    public class ComicServiceTests
+    {
+        private MockFileHelper _mockFileHelper = null!;
+        private MockLogger _mockLogger = null!;
+        private ComicService _comicService = null!;
+        private string _testFileName = "comics.csv";
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _mockFileHelper = new MockFileHelper();
+            _mockLogger = new MockLogger();
+
+            // Simulate an empty file initially for most tests, or a file that can be read
+            _mockFileHelper.FileContents[_testFileName] = "";
+            _mockFileHelper.FileLinesForGenericRead[_testFileName] = new List<string>();
+
+            _comicService = new ComicService(_mockFileHelper, _mockLogger);
+        }
+
+        // --- AddComic Tests ---
+        [TestMethod]
+        public void AddComic_NewComic_AddsToListAndSaves()
+        {
+            // Arrange
+            var comic = new Comic { Title = "Test Comic 1", Author = "Author A", Isbn = "1", Genre = "GenreA" };
+
+            // Act
+            _comicService.AddComic(comic);
+            var allComics = _comicService.GetAllComics();
+
+            // Assert
+            Assert.AreEqual(1, allComics.Count);
+            Assert.AreEqual("Test Comic 1", allComics[0].Title);
+            Assert.IsTrue(_mockFileHelper.FileContents.ContainsKey(_testFileName));
+            Assert.IsTrue(_mockFileHelper.FileContents[_testFileName].Contains("Test Comic 1"));
+            Assert.AreEqual(1, comic.Id, "Comic ID should be assigned."); // Check if ID is generated
+            Assert.IsTrue(_mockLogger.LoggedMessages.Any(m => m.Contains("已新增至記憶體列表") && m.Contains("Test Comic 1")));
+            Assert.IsTrue(_mockLogger.LoggedMessages.Any(m => m.Contains("已成功將 1 本漫畫儲存到")));
+        }
+
+        [TestMethod]
+        public void AddComic_MultipleComics_AssignsSequentialIds()
+        {
+            // Arrange
+            var comic1 = new Comic { Title = "Comic A", Author = "Auth1", Isbn = "11", Genre = "G1" };
+            var comic2 = new Comic { Title = "Comic B", Author = "Auth2", Isbn = "22", Genre = "G2" };
+
+            // Act
+            _comicService.AddComic(comic1);
+            _comicService.AddComic(comic2);
+            var allComics = _comicService.GetAllComics();
+
+            // Assert
+            Assert.AreEqual(2, allComics.Count);
+            Assert.AreEqual(1, comic1.Id);
+            Assert.AreEqual(2, comic2.Id);
+            Assert.IsTrue(_mockFileHelper.FileContents[_testFileName].Contains("Comic A"));
+            Assert.IsTrue(_mockFileHelper.FileContents[_testFileName].Contains("Comic B"));
+            Assert.IsTrue(_mockLogger.LoggedMessages.Count(m => m.Contains("已為漫畫") && m.Contains("產生新的ID")) == 2);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void AddComic_NullComic_ThrowsArgumentNullException()
+        {
+            // Arrange
+            Comic? comic = null;
+
+            // Act
+            _comicService.AddComic(comic!); // Test expects this to throw
+
+            // Assert - Exception expected
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void AddComic_ComicWithExistingId_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            // Simulate loading a comic with Id = 1
+             _mockFileHelper.FileLinesForGenericRead[_testFileName] = new List<string>
+            {
+                "1,\"PreExisting Comic\",\"AuthorX\",\"ISBNX\",\"GenreX\",False,0,,,"
+            };
+            _comicService = new ComicService(_mockFileHelper, _mockLogger); // Re-initialize to load the pre-existing comic
+
+            var comicWithExistingId = new Comic { Id = 1, Title = "New Comic with Old ID", Author = "Author Y", Isbn = "ISBNY", Genre = "GenreY" };
+
+            // Act
+            _comicService.AddComic(comicWithExistingId);
+
+            // Assert - Exception expected, check log for specific message
+        }
+
+        // Placeholder for more tests (Update, Delete, Get, Search, Load, etc.)
+
+        // --- UpdateComic Tests ---
+        [TestMethod]
+        public void UpdateComic_ExistingComic_UpdatesDetailsAndSaves()
+        {
+            // Arrange
+            var initialComic = new Comic { Id = 1, Title = "Old Title", Author = "Old Author", Isbn = "123", Genre = "OldGenre" };
+            _comicService.AddComic(initialComic); // Add it first
+
+            var updatedComicInfo = new Comic { Id = 1, Title = "New Title", Author = "New Author", Isbn = "123Updated", Genre = "NewGenre", IsRented = initialComic.IsRented, RentedToMemberId = initialComic.RentedToMemberId };
+
+            // Act
+            _comicService.UpdateComic(updatedComicInfo);
+            var retrievedComic = _comicService.GetComicById(1);
+
+            // Assert
+            Assert.IsNotNull(retrievedComic);
+            Assert.AreEqual("New Title", retrievedComic.Title);
+            Assert.AreEqual("New Author", retrievedComic.Author);
+            Assert.AreEqual("123Updated", retrievedComic.Isbn);
+            Assert.AreEqual("NewGenre", retrievedComic.Genre);
+            Assert.IsTrue(_mockFileHelper.FileContents[_testFileName].Contains("New Title"));
+            Assert.IsFalse(_mockFileHelper.FileContents[_testFileName].Contains("Old Title"));
+            Assert.IsTrue(_mockLogger.LoggedMessages.Any(m => m.Contains("漫畫屬性已在記憶體中更新") && m.Contains("New Title")));
+            Assert.IsTrue(_mockLogger.LoggedMessages.Any(m => m.Contains("漫畫更新已保存到檔案") && m.Contains("New Title")));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void UpdateComic_NullComic_ThrowsArgumentNullException()
+        {
+            // Act
+            _comicService.UpdateComic(null!);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void UpdateComic_NonExistentComic_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var comicToUpdate = new Comic { Id = 999, Title = "Non Existent", Author = "Ghost", Isbn = "000", Genre = "Mystery" };
+
+            // Act
+            _comicService.UpdateComic(comicToUpdate);
+        }
+
+        // --- DeleteComic Tests ---
+        [TestMethod]
+        public void DeleteComic_ExistingNonRentedComic_RemovesFromListAndSaves()
+        {
+            // Arrange
+            var comic = new Comic { Id = 1, Title = "To Be Deleted", Author = "Author D", Isbn = "del1", Genre = "Action", IsRented = false };
+            _comicService.AddComic(comic);
+            Assert.AreEqual(1, _comicService.GetAllComics().Count, "Comic should be added before deletion.");
+
+            // Act
+            _comicService.DeleteComic(1);
+            var allComics = _comicService.GetAllComics();
+
+            // Assert
+            Assert.AreEqual(0, allComics.Count);
+            Assert.IsFalse(_mockFileHelper.FileContents[_testFileName].Contains("To Be Deleted"));
+            Assert.IsTrue(_mockLogger.LoggedMessages.Any(m => m.Contains("已從記憶體列表移除") && m.Contains("To Be Deleted")));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void DeleteComic_NonExistentComic_ThrowsInvalidOperationException()
+        {
+            // Act
+            _comicService.DeleteComic(999); // ID that doesn't exist
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void DeleteComic_RentedComic_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var rentedComic = new Comic { Id = 1, Title = "Rented Comic", Author = "Author R", Isbn = "rent1", Genre = "Drama", IsRented = true, RentedToMemberId = 1 };
+            _comicService.AddComic(rentedComic);
+
+            // Act
+            _comicService.DeleteComic(1); // Attempt to delete a rented comic
+        }
+
+        // --- GetComicById Tests ---
+        [TestMethod]
+        public void GetComicById_ExistingId_ReturnsComic()
+        {
+            // Arrange
+            var comic1 = new Comic { Id = 1, Title = "FindMe", Author = "AuthorF", Isbn = "find1", Genre = "Search" };
+            _comicService.AddComic(comic1);
+             var comic2 = new Comic { Id = 2, Title = "AnotherComic", Author = "AuthorA", Isbn = "find2", Genre = "Search" };
+            _comicService.AddComic(comic2);
+
+
+            // Act
+            var foundComic = _comicService.GetComicById(1);
+
+            // Assert
+            Assert.IsNotNull(foundComic);
+            Assert.AreEqual(1, foundComic.Id);
+            Assert.AreEqual("FindMe", foundComic.Title);
+        }
+
+        [TestMethod]
+        public void GetComicById_NonExistentId_ReturnsNull()
+        {
+            // Arrange
+            var comic1 = new Comic { Id = 1, Title = "Exists", Author = "AuthorE", Isbn = "exist1", Genre = "Present" };
+            _comicService.AddComic(comic1);
+
+            // Act
+            var foundComic = _comicService.GetComicById(999);
+
+            // Assert
+            Assert.IsNull(foundComic);
+            Assert.IsTrue(_mockLogger.LoggedMessages.Any(m => m.Contains("找不到ID為: 999 的漫畫")));
+        }
+
+        // --- GetAllComics Tests ---
+        [TestMethod]
+        public void GetAllComics_WhenNoComics_ReturnsEmptyList()
+        {
+            // Arrange
+            // _comicService is initialized with no comics by default in TestInitialize
+
+            // Act
+            var allComics = _comicService.GetAllComics();
+
+            // Assert
+            Assert.IsNotNull(allComics);
+            Assert.AreEqual(0, allComics.Count);
+        }
+
+        [TestMethod]
+        public void GetAllComics_WhenComicsExist_ReturnsAllComics()
+        {
+            // Arrange
+            _comicService.AddComic(new Comic { Id = 1, Title = "Comic 1", Author = "A1", Isbn = "I1", Genre = "G1" });
+            _comicService.AddComic(new Comic { Id = 2, Title = "Comic 2", Author = "A2", Isbn = "I2", Genre = "G2" });
+
+            // Act
+            var allComics = _comicService.GetAllComics();
+
+            // Assert
+            Assert.IsNotNull(allComics);
+            Assert.AreEqual(2, allComics.Count);
+            Assert.IsTrue(allComics.Any(c => c.Title == "Comic 1"));
+            Assert.IsTrue(allComics.Any(c => c.Title == "Comic 2"));
+        }
+
+        // --- SearchComics Tests ---
+        [TestMethod]
+        public void SearchComics_ByTitle_ReturnsMatchingComics()
+        {
+            // Arrange
+            _comicService.AddComic(new Comic { Title = "Spider-Man Adventures", Author = "Marvel", Isbn = "S1", Genre = "Superhero" });
+            _comicService.AddComic(new Comic { Title = "Amazing Spider-Man", Author = "Marvel", Isbn = "S2", Genre = "Superhero" });
+            _comicService.AddComic(new Comic { Title = "Batman Chronicles", Author = "DC", Isbn = "B1", Genre = "Superhero" });
+
+            // Act
+            var results = _comicService.SearchComics("Spider-Man");
+
+            // Assert
+            Assert.AreEqual(2, results.Count);
+            Assert.IsTrue(results.All(c => c.Title.Contains("Spider-Man")));
+        }
+
+        [TestMethod]
+        public void SearchComics_ByAuthor_ReturnsMatchingComics()
+        {
+            // Arrange
+             _comicService.AddComic(new Comic { Title = "Comic X", Author = "Author Test", Isbn = "CX", Genre = "Test" });
+            _comicService.AddComic(new Comic { Title = "Comic Y", Author = "Another Author", Isbn = "CY", Genre = "Test" });
+            _comicService.AddComic(new Comic { Title = "Comic Z", Author = "Author Test", Isbn = "CZ", Genre = "Test" });
+
+
+            // Act
+            var results = _comicService.SearchComics("Author Test");
+
+            // Assert
+            Assert.AreEqual(2, results.Count);
+            Assert.IsTrue(results.All(c => c.Author == "Author Test"));
+        }
+
+        [TestMethod]
+        public void SearchComics_ById_ReturnsMatchingComic()
+        {
+            // Arrange
+            _comicService.AddComic(new Comic { Id=1, Title = "Unique ID Comic", Author = "AuthorU", Isbn = "UID1", Genre = "Unique" });
+             _comicService.AddComic(new Comic { Id=2, Title = "Another ID Comic", Author = "AuthorA", Isbn = "AID2", Genre = "Another" });
+
+
+            // Act
+            var results = _comicService.SearchComics("1"); // Search by ID as string
+
+            // Assert
+            Assert.AreEqual(1, results.Count);
+            Assert.AreEqual("Unique ID Comic", results[0].Title);
+        }
+
+
+        [TestMethod]
+        public void SearchComics_NoMatch_ReturnsEmptyList()
+        {
+            // Arrange
+            _comicService.AddComic(new Comic { Title = "X-Men", Author = "Marvel", Isbn = "X1", Genre = "Superhero" });
+
+            // Act
+            var results = _comicService.SearchComics("NonExistentTerm");
+
+            // Assert
+            Assert.AreEqual(0, results.Count);
+        }
+
+        [TestMethod]
+        public void SearchComics_NullOrEmptyTerm_ReturnsAllComics()
+        {
+            // Arrange
+            _comicService.AddComic(new Comic { Title = "Comic A", Author = "AuthA", Isbn = "CA", Genre = "G_A" });
+            _comicService.AddComic(new Comic { Title = "Comic B", Author = "AuthB", Isbn = "CB", Genre = "G_B" });
+
+            // Act
+            var resultsNullTerm = _comicService.SearchComics(null);
+            var resultsEmptyTerm = _comicService.SearchComics("");
+
+            // Assert
+            Assert.AreEqual(2, resultsNullTerm.Count);
+            Assert.AreEqual(2, resultsEmptyTerm.Count);
+        }
+
+        // --- GetComicsByGenre Tests ---
+        [TestMethod]
+        public void GetComicsByGenre_ExistingGenre_ReturnsMatchingComics()
+        {
+            // Arrange
+            _comicService.AddComic(new Comic { Title = "Hero Comic 1", Author = "Writer H", Isbn = "H1", Genre = "Superhero" });
+            _comicService.AddComic(new Comic { Title = "SciFi Comic 1", Author = "Writer S", Isbn = "S1", Genre = "Sci-Fi" });
+            _comicService.AddComic(new Comic { Title = "Hero Comic 2", Author = "Writer H2", Isbn = "H2", Genre = "Superhero" });
+
+            // Act
+            var results = _comicService.GetComicsByGenre("Superhero");
+
+            // Assert
+            Assert.AreEqual(2, results.Count);
+            Assert.IsTrue(results.All(c => c.Genre == "Superhero"));
+        }
+
+        [TestMethod]
+        public void GetComicsByGenre_NonExistentGenre_ReturnsEmptyList()
+        {
+            // Arrange
+            _comicService.AddComic(new Comic { Title = "Manga One", Author = "Mangaka", Isbn = "M1", Genre = "Manga" });
+
+            // Act
+            var results = _comicService.GetComicsByGenre("Fantasy");
+
+            // Assert
+            Assert.AreEqual(0, results.Count);
+        }
+
+        [TestMethod]
+        public void GetComicsByGenre_NullOrEmptyGenre_ReturnsAllComics()
+        {
+            // Arrange
+             _comicService.AddComic(new Comic { Title = "Any Comic 1", Author = "AC1", Isbn = "AC1", Genre = "G1" });
+            _comicService.AddComic(new Comic { Title = "Any Comic 2", Author = "AC2", Isbn = "AC2", Genre = "G2" });
+
+            // Act
+            var resultsNullGenre = _comicService.GetComicsByGenre(null!); // Test with null
+            var resultsEmptyGenre = _comicService.GetComicsByGenre("");   // Test with empty string
+
+            // Assert
+            Assert.AreEqual(2, resultsNullGenre.Count, "Search with null genre should return all comics.");
+            Assert.AreEqual(2, resultsEmptyGenre.Count, "Search with empty genre should return all comics.");
+        }
+
+        // --- Constructor and LoadComicsFromFile (implicitly tested) Tests ---
+        [TestMethod]
+        public void Constructor_LoadsComicsFromValidFile()
+        {
+            // Arrange
+            _mockFileHelper.FileLinesForGenericRead[_testFileName] = new List<string>
+            {
+                "1,\"Loaded Comic 1\",\"Loader\",\"L1\",\"LoadGenre\",False,0,,,",
+                "2,\"Loaded Comic 2\",\"Loader\",\"L2\",\"LoadGenre\",True,101,2023-01-01T00:00:00,,",
+            };
+            // Re-initialize ComicService to trigger constructor load with new mock setup
+            _comicService = new ComicService(_mockFileHelper, _mockLogger);
+
+            // Act
+            var allComics = _comicService.GetAllComics();
+
+            // Assert
+            Assert.AreEqual(2, allComics.Count);
+            Assert.IsTrue(allComics.Any(c => c.Title == "Loaded Comic 1"));
+            Assert.IsTrue(allComics.Any(c => c.Title == "Loaded Comic 2" && c.IsRented));
+            Assert.IsTrue(_mockLogger.LoggedMessages.Any(m => m.Contains("成功從 'comics.csv' (同步) 載入 2 本漫畫。")));
+        }
+
+        [TestMethod]
+        public void Constructor_HandlesEmptyFile_InitializesEmptyComicList()
+        {
+            // Arrange
+            _mockFileHelper.FileLinesForGenericRead[_testFileName] = new List<string>(); // Empty file
+             // Re-initialize ComicService
+            _comicService = new ComicService(_mockFileHelper, _mockLogger);
+
+            // Act
+            var allComics = _comicService.GetAllComics();
+
+            // Assert
+            Assert.AreEqual(0, allComics.Count);
+             Assert.IsTrue(_mockLogger.LoggedMessages.Any(m => m.Contains("成功從 'comics.csv' (同步) 載入 0 本漫畫。")));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ApplicationException))] // As per ComicService's error handling
+        public void Constructor_HandlesCorruptedFile_ThrowsApplicationException()
+        {
+            // Arrange
+            _mockFileHelper.ReadFileFunc = (fileName) => { throw new FormatException("Corrupted data"); };
+            // This setup for ReadFile<T> will cause Comic.FromCsvString to fail if not handled by ReadFileFunc override
+            _mockFileHelper.FileLinesForGenericRead[_testFileName] = new List<string> { "this is not valid csv" };
+
+            // We need to ensure the generic ReadFile<T> in MockFileHelper throws FormatException when parser fails
+            // or ensure the parser itself (Comic.FromCsvString) throws it and it's caught by ComicService.
+            // For this test, we'll assume Comic.FromCsvString will throw FormatException for "this is not valid csv"
+            // and ComicService constructor catches it and wraps it in ApplicationException.
+
+            // Re-initialize ComicService
+            _comicService = new ComicService(_mockFileHelper, _mockLogger);
+
+            // Act & Assert: Exception expected
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ApplicationException))] // As per ComicService's error handling
+        public void Constructor_HandlesIOExceptionOnLoad_ThrowsApplicationException()
+        {
+            // Arrange
+            _mockFileHelper.ReadFileFunc = (fileName) => { throw new IOException("Disk error"); };
+             _mockFileHelper.FileLinesForGenericRead[_testFileName] = new List<string>(); // Need to set this up even if ReadFile throws
+            // Re-initialize ComicService
+            _comicService = new ComicService(_mockFileHelper, _mockLogger);
+            // Act & Assert: Exception expected
+        }
+
+        // --- ReloadAsync Tests ---
+        [TestMethod]
+        public async Task ReloadAsync_LoadsComicsFromValidFile()
+        {
+            // Arrange
+            // Service starts empty
+            _comicService = new ComicService(new MockFileHelper(), _mockLogger); // Start with a fresh MockFileHelper for this test
+            Assert.AreEqual(0, _comicService.GetAllComics().Count);
+
+            // Setup the (new) mock file helper for ReloadAsync
+            _mockFileHelper.FileContents[_testFileName] =
+                "1,\"Reloaded Comic 1\",\"Reloader\",\"R1\",\"ReloadGenre\",False,0,,,
+" +
+                "2,\"Reloaded Comic 2\",\"Reloader\",\"R2\",\"ReloadGenre\",True,102,2023-02-01T00:00:00,,";
+             _comicService = new ComicService(_mockFileHelper, _mockLogger); // Re-assign service with the mock that has data for async read
+
+            // Act
+            await _comicService.ReloadAsync();
+            var allComics = _comicService.GetAllComics();
+
+            // Assert
+            Assert.AreEqual(2, allComics.Count);
+            Assert.IsTrue(allComics.Any(c => c.Title == "Reloaded Comic 1"));
+            Assert.IsTrue(_mockLogger.LoggedMessages.Any(m => m.Contains("ComicService 已非同步重新載入。已載入 2 本漫畫。")));
+        }
+
+        [TestMethod]
+        public async Task ReloadAsync_FileNotFound_ReturnsEmptyListAndLogsWarning()
+        {
+            // Arrange
+             _mockFileHelper.ReadFileAsyncFunc = async (filePath) =>
+            {
+                await Task.CompletedTask; // Simulate async behavior
+                throw new FileNotFoundException("Async file not found");
+            };
+            _comicService = new ComicService(_mockFileHelper, _mockLogger); // Re-assign service with this specific mock setup
+
+            // Act
+            await _comicService.ReloadAsync();
+            var comics = _comicService.GetAllComics();
+
+            // Assert
+            Assert.AreEqual(0, comics.Count);
+            Assert.IsTrue(_mockLogger.LoggedWarnings.Any(w => w.Contains($"漫畫檔案 '{_testFileName}' (非同步) 找不到。返回空列表。")));
+        }
+
+
+        // --- GetAdminComicStatusViewModels Tests ---
+        [TestMethod]
+        public void GetAdminComicStatusViewModels_NoComics_ReturnsEmptyList()
+        {
+            // Arrange
+            var members = new List<Member>();
+
+            // Act
+            var viewModels = _comicService.GetAdminComicStatusViewModels(members);
+
+            // Assert
+            Assert.AreEqual(0, viewModels.Count);
+        }
+
+        [TestMethod]
+        public void GetAdminComicStatusViewModels_ComicsExist_ReturnsCorrectViewModels()
+        {
+            // Arrange
+            _comicService.AddComic(new Comic { Id = 1, Title = "Comic Alpha", Author = "AuthX", Genre = "GAlpha", IsRented = false, RentedToMemberId = 0 });
+            _comicService.AddComic(new Comic { Id = 2, Title = "Comic Beta", Author = "AuthY", Genre = "GBeta", IsRented = true, RentedToMemberId = 101, RentalDate = DateTime.Now.AddDays(-5) });
+            _comicService.AddComic(new Comic { Id = 3, Title = "Comic Gamma", Author = "AuthZ", Genre = "GGamma", IsRented = true, RentedToMemberId = 999 }); // Member does not exist
+
+            var members = new List<Member>
+            {
+                new Member { Id = 101, Name = "John Doe", PhoneNumber = "555-1234" }
+            };
+
+            // Act
+            var viewModels = _comicService.GetAdminComicStatusViewModels(members);
+
+            // Assert
+            Assert.AreEqual(3, viewModels.Count);
+
+            var vmAlpha = viewModels.First(vm => vm.Id == 1);
+            Assert.AreEqual("Comic Alpha", vmAlpha.Title);
+            Assert.AreEqual("在館中", vmAlpha.Status);
+            Assert.IsNull(vmAlpha.BorrowerName);
+
+            var vmBeta = viewModels.First(vm => vm.Id == 2);
+            Assert.AreEqual("Comic Beta", vmBeta.Title);
+            Assert.AreEqual("被借閱", vmBeta.Status);
+            Assert.AreEqual("John Doe", vmBeta.BorrowerName);
+            Assert.AreEqual("555-1234", vmBeta.BorrowerPhoneNumber);
+            Assert.IsNotNull(vmBeta.RentalDate);
+
+            var vmGamma = viewModels.First(vm => vm.Id == 3);
+            Assert.AreEqual("Comic Gamma", vmGamma.Title);
+            Assert.AreEqual("被借閱", vmGamma.Status);
+            Assert.AreEqual("不明", vmGamma.BorrowerName); // Member 999 not in list
+            Assert.IsTrue(_mockLogger.LoggedWarnings.Any(w => w.Contains("找不到ID為 999 的會員")));
+        }
+    }
+}

--- a/ComicRentalSystem_14Days.Tests/ComicTests.cs
+++ b/ComicRentalSystem_14Days.Tests/ComicTests.cs
@@ -1,0 +1,224 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ComicRentalSystem_14Days.Models;
+using System;
+using System.Globalization; // Required for DateTime parsing assertions
+
+namespace ComicRentalSystem_14Days.Tests
+{
+    [TestClass]
+    public class ComicTests
+    {
+        [TestMethod]
+        public void ToCsvString_ValidComic_ReturnsCorrectCsvFormat()
+        {
+            // Arrange
+            var comic = new Comic
+            {
+                Id = 1,
+                Title = "Spider-Man",
+                Author = "Stan Lee",
+                Isbn = "1234567890",
+                Genre = "Superhero",
+                IsRented = false,
+                RentedToMemberId = 0,
+                RentalDate = new DateTime(2023, 1, 15, 10, 30, 0, DateTimeKind.Unspecified),
+                ReturnDate = new DateTime(2023, 2, 15, 10, 30, 0, DateTimeKind.Unspecified),
+                ActualReturnTime = null
+            };
+            var expectedCsv = "1,\"Spider-Man\",\"Stan Lee\",\"1234567890\",\"Superhero\",False,0,2023-01-15T10:30:00,2023-02-15T10:30:00,";
+
+            // Act
+            var actualCsv = comic.ToCsvString();
+
+            // Assert
+            Assert.AreEqual(expectedCsv, actualCsv);
+        }
+
+        [TestMethod]
+        public void ToCsvString_ComicWithQuotesInTitle_ReturnsCsvWithEscapedQuotes()
+        {
+            // Arrange
+            var comic = new Comic
+            {
+                Id = 2,
+                Title = "The \"Amazing\" Spider-Man",
+                Author = "Stan Lee",
+                Isbn = "0987654321",
+                Genre = "Superhero",
+                IsRented = true,
+                RentedToMemberId = 101,
+                RentalDate = null,
+                ReturnDate = null,
+                ActualReturnTime = null
+            };
+            var expectedCsv = "2,\"The \"\"Amazing\"\" Spider-Man\",\"Stan Lee\",\"0987654321\",\"Superhero\",True,101,,,";
+
+
+            // Act
+            var actualCsv = comic.ToCsvString();
+
+            // Assert
+            Assert.AreEqual(expectedCsv, actualCsv);
+        }
+
+        [TestMethod]
+        public void ToCsvString_ComicWithNullDates_ReturnsCsvWithEmptyDateFields()
+        {
+            // Arrange
+            var comic = new Comic
+            {
+                Id = 3,
+                Title = "Hulk",
+                Author = "Stan Lee",
+                Isbn = "1122334455",
+                Genre = "Superhero",
+                IsRented = false,
+                RentedToMemberId = 0,
+                RentalDate = null,
+                ReturnDate = null,
+                ActualReturnTime = null
+            };
+            var expectedCsv = "3,\"Hulk\",\"Stan Lee\",\"1122334455\",\"Superhero\",False,0,,,";
+
+            // Act
+            var actualCsv = comic.ToCsvString();
+
+            // Assert
+            Assert.AreEqual(expectedCsv, actualCsv);
+        }
+
+        [TestMethod]
+        public void FromCsvString_ValidLine_PopulatesComicCorrectly()
+        {
+            // Arrange
+            var csvLine = "1,\"Spider-Man\",\"Stan Lee\",\"1234567890\",\"Superhero\",False,0,2023-01-15T10:30:00,2023-02-15T10:30:00,2023-02-14T12:00:00";
+
+            // Act
+            var comic = Comic.FromCsvString(csvLine);
+
+            // Assert
+            Assert.AreEqual(1, comic.Id);
+            Assert.AreEqual("Spider-Man", comic.Title);
+            Assert.AreEqual("Stan Lee", comic.Author);
+            Assert.AreEqual("1234567890", comic.Isbn);
+            Assert.AreEqual("Superhero", comic.Genre);
+            Assert.IsFalse(comic.IsRented);
+            Assert.AreEqual(0, comic.RentedToMemberId);
+            Assert.AreEqual(new DateTime(2023, 1, 15, 10, 30, 0), comic.RentalDate);
+            Assert.AreEqual(new DateTime(2023, 2, 15, 10, 30, 0), comic.ReturnDate);
+            Assert.AreEqual(new DateTime(2023, 2, 14, 12, 0, 0), comic.ActualReturnTime);
+        }
+
+        [TestMethod]
+        public void FromCsvString_LineWithMissingOptionalDates_PopulatesComicCorrectly()
+        {
+            // Arrange
+            var csvLine = "2,\"Hulk\",\"Stan Lee\",\"1122334455\",\"Superhero\",True,101,,,";
+
+            // Act
+            var comic = Comic.FromCsvString(csvLine);
+
+            // Assert
+            Assert.AreEqual(2, comic.Id);
+            Assert.AreEqual("Hulk", comic.Title);
+            Assert.AreEqual("Stan Lee", comic.Author);
+            Assert.IsTrue(comic.IsRented);
+            Assert.AreEqual(101, comic.RentedToMemberId);
+            Assert.IsNull(comic.RentalDate);
+            Assert.IsNull(comic.ReturnDate);
+            Assert.IsNull(comic.ActualReturnTime);
+        }
+
+        [TestMethod]
+        public void FromCsvString_LineWithEmptyRentedToMemberId_PopulatesAsZero()
+        {
+            // Arrange
+            var csvLine = "3,\"Captain America\",\"Joe Simon\",\"2233445566\",\"Superhero\",False,,,,";
+
+            // Act
+            var comic = Comic.FromCsvString(csvLine);
+
+            // Assert
+            Assert.AreEqual(3, comic.Id);
+            Assert.AreEqual("Captain America", comic.Title);
+            Assert.AreEqual(0, comic.RentedToMemberId);
+            Assert.IsFalse(comic.IsRented);
+            Assert.IsNull(comic.RentalDate);
+            Assert.IsNull(comic.ReturnDate);
+            Assert.IsNull(comic.ActualReturnTime);
+        }
+
+        [TestMethod]
+        public void FromCsvString_LineWithQuotedFieldsContainingCommasAndQuotes_PopulatesComicCorrectly()
+        {
+            // Arrange
+            var csvLine = "4,\"Alias, Vol. 1: \"\"The Pulse\"\"\",\"Bendis, Brian Michael\",\"3344556677\",\"Crime Noir\",False,0,,,";
+
+            // Act
+            var comic = Comic.FromCsvString(csvLine);
+
+            // Assert
+            Assert.AreEqual(4, comic.Id);
+            Assert.AreEqual("Alias, Vol. 1: \"The Pulse\"", comic.Title);
+            Assert.AreEqual("Bendis, Brian Michael", comic.Author);
+            Assert.AreEqual("Crime Noir", comic.Genre);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void FromCsvString_MalformedLine_InsufficientFields_ThrowsFormatException()
+        {
+            // Arrange
+            var csvLine = "5,\"Too Few\"";
+
+            // Act
+            Comic.FromCsvString(csvLine);
+
+            // Assert - Exception expected
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void FromCsvString_MalformedLine_IncorrectDataTypeForId_ThrowsFormatException()
+        {
+            // Arrange
+            var csvLine = "\"NotANumber\",\"Title\",\"Author\",\"Isbn\",\"Genre\",False,0,,,";
+
+            // Act
+            Comic.FromCsvString(csvLine);
+
+            // Assert - Exception expected
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void FromCsvString_MalformedLine_IncorrectDataTypeForIsRented_ThrowsFormatException()
+        {
+            // Arrange
+            var csvLine = "6,\"Title\",\"Author\",\"Isbn\",\"Genre\",\"NotABoolean\",0,,,";
+
+            // Act
+            Comic.FromCsvString(csvLine);
+
+            // Assert - Exception expected
+        }
+
+        [TestMethod]
+        public void ParseCsvLine_HandlesVariousComplexities()
+        {
+            // Test cases for Comic.ParseCsvLine (which is internal, so we test it via FromCsvString or make it internal visible for testing)
+            var csvLineWithEmptyFields = "7,\"Title\",\"Author\",,,False,0,,,";
+            var comic1 = Comic.FromCsvString(csvLineWithEmptyFields);
+            Assert.AreEqual(string.Empty, comic1.Isbn);
+            Assert.AreEqual(string.Empty, comic1.Genre);
+
+            var csvLineWithSpaces = "8 , \"Spaced Title\" , \"Spaced Author\" , spaced_isbn , spaced_genre , False , 0 , ,,";
+            var comic2 = Comic.FromCsvString(csvLineWithSpaces);
+            Assert.AreEqual(8, comic2.Id);
+            Assert.AreEqual("Spaced Title", comic2.Title);
+            Assert.AreEqual("Spaced Author", comic2.Author);
+            Assert.AreEqual("spaced_isbn", comic2.Isbn);
+            Assert.AreEqual("spaced_genre", comic2.Genre);
+        }
+    }
+}

--- a/ComicRentalSystem_14Days.Tests/GlobalUsings.cs
+++ b/ComicRentalSystem_14Days.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/ComicRentalSystem_14Days.Tests/MockFileHelper.cs
+++ b/ComicRentalSystem_14Days.Tests/MockFileHelper.cs
@@ -1,0 +1,156 @@
+using ComicRentalSystem_14Days.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ComicRentalSystem_14Days.Tests.Mocks
+{
+    public class MockFileHelper : IFileHelper
+    {
+        // Dictionary to store file content in memory
+        public Dictionary<string, string> FileContents = new Dictionary<string, string>();
+        // Dictionary to store lines for generic ReadFile<T>
+        public Dictionary<string, List<string>> FileLinesForGenericRead = new Dictionary<string, List<string>>();
+
+        // Properties to control mock behavior
+        public Func<string, bool>? FileExistsFunc { get; set; }
+        public Action<string>? DeleteFileAction { get; set; }
+        public Func<string, string>? ReadFileFunc { get; set; }
+        public Func<string, Task<string>>? ReadFileAsyncFunc { get; set; }
+        public Action<string, string>? WriteFileAction { get; set; }
+        public Func<string, string, Task>? WriteFileAsyncAction { get; set; }
+
+
+        public bool FileExists(string filePath)
+        {
+            if (FileExistsFunc != null)
+            {
+                return FileExistsFunc(filePath);
+            }
+            return FileContents.ContainsKey(filePath) || FileLinesForGenericRead.ContainsKey(filePath);
+        }
+
+        public void DeleteFile(string filePath)
+        {
+            if (DeleteFileAction != null)
+            {
+                DeleteFileAction(filePath);
+                return;
+            }
+            FileContents.Remove(filePath);
+            FileLinesForGenericRead.Remove(filePath);
+        }
+
+        public string ReadFile(string fileName)
+        {
+            if (ReadFileFunc != null)
+            {
+                return ReadFileFunc(fileName);
+            }
+            if (FileContents.TryGetValue(fileName, out var content))
+            {
+                return content;
+            }
+            throw new FileNotFoundException($"Mock file not found: {fileName}");
+        }
+
+        public async Task<string> ReadFileAsync(string filePath)
+        {
+            if (ReadFileAsyncFunc != null)
+            {
+                return await ReadFileAsyncFunc(filePath);
+            }
+            if (FileContents.TryGetValue(filePath, out var content))
+            {
+                return content;
+            }
+            throw new FileNotFoundException($"Mock async file not found: {filePath}");
+        }
+
+        public List<T> ReadFile<T>(string fileName, Func<string, T> parser)
+        {
+            if (FileLinesForGenericRead.TryGetValue(fileName, out var lines))
+            {
+                return lines.Select(parser).ToList();
+            }
+            if (FileContents.TryGetValue(fileName, out var content)) // Fallback to FileContents if specific lines aren't set
+            {
+                 // Basic split by newline, might need adjustment based on actual CSV structure if complex
+                return content.Split(new[] { Environment.NewLine, "\n", "\r\n" }, StringSplitOptions.RemoveEmptyEntries)
+                              .Select(parser).ToList();
+            }
+            throw new FileNotFoundException($"Mock file for generic read not found: {fileName}");
+        }
+
+        public void WriteFile(string fileName, string content)
+        {
+            if (WriteFileAction != null)
+            {
+                WriteFileAction(fileName, content);
+                return;
+            }
+            FileContents[fileName] = content;
+        }
+
+        public async Task WriteFileAsync(string filePath, string content)
+        {
+            if (WriteFileAsyncAction != null)
+            {
+                await WriteFileAsyncAction(filePath, content);
+                return;
+            }
+            FileContents[filePath] = content;
+            await Task.CompletedTask;
+        }
+
+        public void WriteFile<T>(string fileName, IEnumerable<T> items, Func<T, string> formatter)
+        {
+            var sb = new StringBuilder();
+            foreach (var item in items)
+            {
+                sb.AppendLine(formatter(item));
+            }
+            FileContents[fileName] = sb.ToString().TrimEnd(Environment.NewLine.ToCharArray()); // Trim trailing newline
+            // Also update FileLinesForGenericRead for consistency if it's read back with ReadFile<T>
+            FileLinesForGenericRead[fileName] = items.Select(formatter).ToList();
+        }
+
+        public string GetFullFilePath(string fileName)
+        {
+            // For mocks, we can just return the fileName as is, or a predefined path
+            return Path.Combine("C:\mock\path", fileName);
+        }
+
+        public void MoveFile(string sourcePath, string destinationPath)
+        {
+            if (FileContents.TryGetValue(sourcePath, out var content))
+            {
+                FileContents[destinationPath] = content;
+                FileContents.Remove(sourcePath);
+            }
+            else
+            {
+                throw new FileNotFoundException($"Mock source file not found for move: {sourcePath}");
+            }
+        }
+
+        public void CopyFile(string sourcePath, string destinationPath, bool overwrite)
+        {
+            if (FileContents.ContainsKey(destinationPath) && !overwrite)
+            {
+                throw new IOException($"Mock destination file exists and overwrite is false: {destinationPath}");
+            }
+            if (FileContents.TryGetValue(sourcePath, out var content))
+            {
+                FileContents[destinationPath] = content;
+            }
+            else
+            {
+                throw new FileNotFoundException($"Mock source file not found for copy: {sourcePath}");
+            }
+        }
+    }
+}

--- a/ComicRentalSystem_14Days.Tests/MockLogger.cs
+++ b/ComicRentalSystem_14Days.Tests/MockLogger.cs
@@ -1,0 +1,56 @@
+using ComicRentalSystem_14Days.Interfaces;
+using System;
+using System.Collections.Generic;
+
+namespace ComicRentalSystem_14Days.Tests.Mocks
+{
+    public class MockLogger : ILogger
+    {
+        public List<string> LoggedMessages { get; } = new List<string>();
+        public List<(string message, Exception? ex)> LoggedErrors { get; } = new List<(string, Exception?)>();
+        public List<string> LoggedWarnings { get; } = new List<string>();
+        public List<string> LoggedInformations { get; } = new List<string>();
+        public List<string> LoggedDebugs { get; } = new List<string>();
+
+        public void Log(string message)
+        {
+            LoggedMessages.Add(message);
+        }
+
+        public void Log(string message, Exception ex)
+        {
+            LoggedMessages.Add($"{message} Exception: {ex?.Message}");
+            // Optionally, store the exception too if needed for assertions
+        }
+
+        public void LogError(string message, Exception? ex = null)
+        {
+            LoggedErrors.Add((message, ex));
+        }
+
+        public void LogWarning(string message)
+        {
+            LoggedWarnings.Add(message);
+        }
+
+        public void LogInformation(string message)
+        {
+            LoggedInformations.Add(message);
+        }
+
+        public void LogDebug(string message)
+        {
+            LoggedDebugs.Add(message);
+        }
+
+        // Helper method to clear logs between tests
+        public void ClearAllLogs()
+        {
+            LoggedMessages.Clear();
+            LoggedErrors.Clear();
+            LoggedWarnings.Clear();
+            LoggedInformations.Clear();
+            LoggedDebugs.Clear();
+        }
+    }
+}

--- a/ComicRentalSystem_14Days.sln
+++ b/ComicRentalSystem_14Days.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.13.35931.197 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ComicRentalSystem_14Days", "ComicRentalSystem_14Days\ComicRentalSystem_14Days.csproj", "{76A88E66-AB0D-4D34-AC97-BD5532ECDC38}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ComicRentalSystem_14Days.Tests", "ComicRentalSystem_14Days.Tests\ComicRentalSystem_14Days.Tests.csproj", "{72AC8357-BD66-4346-BF99-10D6CD31362A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{76A88E66-AB0D-4D34-AC97-BD5532ECDC38}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{76A88E66-AB0D-4D34-AC97-BD5532ECDC38}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{76A88E66-AB0D-4D34-AC97-BD5532ECDC38}.Release|Any CPU.Build.0 = Release|Any CPU
+		{72AC8357-BD66-4346-BF99-10D6CD31362A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{72AC8357-BD66-4346-BF99-10D6CD31362A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72AC8357-BD66-4346-BF99-10D6CD31362A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{72AC8357-BD66-4346-BF99-10D6CD31362A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
此提交新增了一個 MSTest 測試專案 `ComicRentalSystem_14Days.Tests`，包含針對 `Comic` 模型與 `ComicService` 類別的完整單元測試套件。

對 `Comic.cs` 的測試涵蓋：

* CSV 序列化（`ToCsvString`），包含特殊字元與空日期的處理。
* CSV 反序列化（`FromCsvString`），針對有效行、缺少選填欄位、帶引號的值、格式錯誤或無效輸入進行測試。

對 `ComicService.cs` 的測試涵蓋：

* CRUD 操作：AddComic、UpdateComic、DeleteComic。
* 取用方法：GetComicById、GetAllComics。
* 搜尋與過濾邏輯：SearchComics、GetComicsByGenre。
* 檔案載入邏輯（建構子與 ReloadAsync）：處理有效檔案、空檔案、毀損資料與檔案 I/O 錯誤。
* 檢視模型產生：GetAdminComicStatusViewModels。

測試專案中建立了 `IFileHelper` 與 `ILogger` 的模擬實作，以利對服務邏輯進行獨立測試。
