### PR TITLE
Add MSTest project

### DIFF
--- a/ComicRentalSystem.Tests/ComicRentalSystem.Tests.csproj
+++ b/ComicRentalSystem.Tests/ComicRentalSystem.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ComicRentalSystem_14Days\ComicRentalSystem_14Days.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ComicRentalSystem.Tests/DummyComicService.cs
+++ b/ComicRentalSystem.Tests/DummyComicService.cs
@@ -1,0 +1,23 @@
+using ComicRentalSystem_14Days.Interfaces;
+using ComicRentalSystem_14Days.Models;
+using ComicRentalSystem_14Days.Services;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ComicRentalSystem.Tests
+{
+    public class DummyComicService : IComicService
+    {
+        public event ComicDataChangedEventHandler? ComicsChanged;
+        public Task ReloadAsync() => Task.CompletedTask;
+        public List<Comic> GetAllComics() => new();
+        public Comic? GetComicById(int id) => null;
+        public void AddComic(Comic comic) { }
+        public Task AddComicAsync(Comic comic) { return Task.CompletedTask; }
+        public void UpdateComic(Comic comic) { }
+        public void DeleteComic(int id) { }
+        public List<Comic> GetComicsByGenre(string genreFilter) => new();
+        public List<Comic> SearchComics(string? searchTerm = null) => new();
+        public List<AdminComicStatusViewModel> GetAdminComicStatusViewModels(IEnumerable<Member> allMembers) => new();
+    }
+}

--- a/ComicRentalSystem.Tests/GlobalUsings.cs
+++ b/ComicRentalSystem.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/ComicRentalSystem.Tests/ServiceTests.cs
+++ b/ComicRentalSystem.Tests/ServiceTests.cs
@@ -1,0 +1,134 @@
+using ComicRentalSystem_14Days.Services;
+using ComicRentalSystem_14Days.Models;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace ComicRentalSystem.Tests
+{
+    [TestClass]
+    public class ServiceTests
+    {
+        private string? _originalConfigHome;
+        private string _tempDir = string.Empty;
+        private TestLogger _logger = null!;
+        private AuthenticationService _authService = null!;
+        private ComicService _comicService = null!;
+        private MemberService _memberService = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _logger = new TestLogger();
+            _originalConfigHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+            _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", _tempDir);
+
+            using (var context = new ComicRentalDbContext())
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+            }
+
+            _authService = new AuthenticationService(_logger);
+            _comicService = new ComicService(_logger);
+            _memberService = new MemberService(_logger, new DummyComicService());
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", _originalConfigHome);
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, true);
+            }
+        }
+
+        [TestMethod]
+        public void AuthenticationService_Register_AddsUser()
+        {
+            var result = _authService.Register("testuser", "password", UserRole.Member);
+            Assert.IsTrue(result);
+            using var context = new ComicRentalDbContext();
+            var user = context.Users.SingleOrDefault(u => u.Username == "testuser");
+            Assert.IsNotNull(user);
+            Assert.AreEqual(UserRole.Member, user!.Role);
+        }
+
+        [TestMethod]
+        public void AuthenticationService_Register_Duplicate_ReturnsFalse()
+        {
+            _authService.Register("dupuser", "pass1", UserRole.Member);
+            var result = _authService.Register("dupuser", "pass2", UserRole.Member);
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void AuthenticationService_Login_Success()
+        {
+            _authService.Register("loginuser", "mypw", UserRole.Admin);
+            var user = _authService.Login("loginuser", "mypw");
+            Assert.IsNotNull(user);
+            Assert.AreEqual("loginuser", user!.Username);
+        }
+
+        [TestMethod]
+        public void AuthenticationService_Login_WrongPassword_Increments()
+        {
+            _authService.Register("loginfail", "right", UserRole.Member);
+            var result = _authService.Login("loginfail", "wrong");
+            Assert.IsNull(result);
+            using var context = new ComicRentalDbContext();
+            var user = context.Users.Single(u => u.Username == "loginfail");
+            Assert.AreEqual(1, user.FailedLoginAttempts);
+        }
+
+        [TestMethod]
+        public void AuthenticationService_Login_LockoutAfterFiveAttempts()
+        {
+            _authService.Register("lockme", "good", UserRole.Member);
+            for (int i = 0; i < 5; i++)
+            {
+                Assert.IsNull(_authService.Login("lockme", "bad"));
+            }
+            using var context = new ComicRentalDbContext();
+            var user = context.Users.Single(u => u.Username == "lockme");
+            Assert.IsTrue(user.LockoutEndDate.HasValue);
+        }
+
+        [TestMethod]
+        public void ComicService_AddComic_SavesToDb()
+        {
+            var comic = new Comic { Title = "A", Author = "B", Isbn = "1", Genre = "G" };
+            _comicService.AddComic(comic);
+            using var context = new ComicRentalDbContext();
+            var fromDb = context.Comics.Single(c => c.Title == "A");
+            Assert.AreNotEqual(0, fromDb.Id);
+        }
+
+        [TestMethod]
+        public void ComicService_AddComic_Invalid_Throws()
+        {
+            var comic = new Comic { Author = "B", Isbn = "1", Genre = "G", Title = "" };
+            Assert.ThrowsException<ArgumentException>(() => _comicService.AddComic(comic));
+        }
+
+        [TestMethod]
+        public void MemberService_AddMember_SavesToDb()
+        {
+            var member = new Member { Name = "M", PhoneNumber = "099", Username = "u" };
+            _memberService.AddMember(member);
+            using var context = new ComicRentalDbContext();
+            var fromDb = context.Members.Single(m => m.Name == "M");
+            Assert.AreNotEqual(0, fromDb.Id);
+        }
+
+        [TestMethod]
+        public void MemberService_AddMember_Invalid_Throws()
+        {
+            var member = new Member { Name = "", PhoneNumber = "" };
+            Assert.ThrowsException<ArgumentException>(() => _memberService.AddMember(member));
+        }
+    }
+}

--- a/ComicRentalSystem.Tests/TestLogger.cs
+++ b/ComicRentalSystem.Tests/TestLogger.cs
@@ -1,0 +1,23 @@
+using ComicRentalSystem_14Days.Interfaces;
+using System;
+using System.Collections.Generic;
+
+namespace ComicRentalSystem.Tests
+{
+    public class TestLogger : ILogger
+    {
+        public List<string> Messages { get; } = new();
+
+        public void Log(string message) => Messages.Add(message);
+
+        public void Log(string message, Exception ex) => Messages.Add($"{message} EX:{ex.Message}");
+
+        public void LogError(string message, Exception? ex = null) => Messages.Add(ex == null ? message : $"{message} EX:{ex.Message}");
+
+        public void LogWarning(string message) => Messages.Add(message);
+
+        public void LogInformation(string message) => Messages.Add(message);
+
+        public void LogDebug(string message) => Messages.Add(message);
+    }
+}

--- a/ComicRentalSystem_14Days.sln
+++ b/ComicRentalSystem_14Days.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.13.35931.197
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ComicRentalSystem_14Days", "ComicRentalSystem_14Days\ComicRentalSystem_14Days.csproj", "{76A88E66-AB0D-4D34-AC97-BD5532ECDC38}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ComicRentalSystem.Tests", "ComicRentalSystem.Tests\ComicRentalSystem.Tests.csproj", "{B5BF4094-5BFF-4776-ACE7-C8751BAD65F8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{76A88E66-AB0D-4D34-AC97-BD5532ECDC38}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{76A88E66-AB0D-4D34-AC97-BD5532ECDC38}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{76A88E66-AB0D-4D34-AC97-BD5532ECDC38}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5BF4094-5BFF-4776-ACE7-C8751BAD65F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5BF4094-5BFF-4776-ACE7-C8751BAD65F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5BF4094-5BFF-4776-ACE7-C8751BAD65F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5BF4094-5BFF-4776-ACE7-C8751BAD65F8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ComicRentalSystem_14Days/ComicRentalSystem_14Days.csproj
+++ b/ComicRentalSystem_14Days/ComicRentalSystem_14Days.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <StartupObject>ComicRentalSystem_14Days.Program</StartupObject>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- add new MSTest project `ComicRentalSystem.Tests`
- include simple `TestLogger` and `DummyComicService`
- cover services with unit tests
- enable Windows targeting in main project
- register test project in solution

## Testing
- `dotnet test ComicRentalSystem.Tests/ComicRentalSystem.Tests.csproj --no-build` *(fails: The argument ... is invalid)*
- `dotnet test ComicRentalSystem_14Days.sln --no-build` *(fails: Microsoft.WindowsDesktop.App runtime not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a83b06dc83278f4843083ad1d871