### PR TITLE
Add cancellable reload service

### DIFF
--- a/ComicRentalSystem_14Days/Forms/RentalForm.cs
+++ b/ComicRentalSystem_14Days/Forms/RentalForm.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
@@ -57,14 +58,15 @@ namespace ComicRentalSystem_14Days.Forms
                 LoadRentalDetails(); 
 
                 _reloadService?.Start(
-                    async () => 
+                    async () =>
                     {
                         LogActivity("自動重新載入資料開始 (非同步)");
-                        if (_comicService != null) await _comicService.ReloadAsync(); 
-                        if (_memberService != null) await _memberService.ReloadAsync(); 
+                        if (_comicService != null) await _comicService.ReloadAsync();
+                        if (_memberService != null) await _memberService.ReloadAsync();
                         LogActivity("自動重新載入資料完成 (非同步)");
                     },
-                    TimeSpan.FromSeconds(30)
+                    TimeSpan.FromSeconds(30),
+                    CancellationToken.None
                 );
 
                 if (cmbMembers.Items.Count == 0)
@@ -481,11 +483,14 @@ namespace ComicRentalSystem_14Days.Forms
         }
         }
 
-        protected override void OnFormClosing(FormClosingEventArgs e)
+        protected override async void OnFormClosing(FormClosingEventArgs e)
         {
             LogActivity("租借表單正在關閉。正在取消訂閱服務事件。");
 
-            _reloadService?.Stop();
+            if (_reloadService != null)
+            {
+                await _reloadService.StopAsync();
+            }
 
             if (_comicService != null)
             {

--- a/ComicRentalSystem_14Days/Services/DataMigrationService.cs
+++ b/ComicRentalSystem_14Days/Services/DataMigrationService.cs
@@ -1,6 +1,7 @@
 using ComicRentalSystem_14Days.Helpers;
 using ComicRentalSystem_14Days.Logging;
 using ComicRentalSystem_14Days.Models;
+using ComicRentalSystem_14Days.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/ComicRentalSystem_14Days/Services/IReloadService.cs
+++ b/ComicRentalSystem_14Days/Services/IReloadService.cs
@@ -9,8 +9,8 @@ namespace ComicRentalSystem_14Days.Services
 {
     public interface IReloadService
     {
-        void Start(Func<Task> reloadAction, TimeSpan interval);
+        Task Start(Func<Task> reloadAction, TimeSpan interval, CancellationToken cancellationToken);
 
-        void Stop();
+        Task StopAsync();
     }
 }


### PR DESCRIPTION
## Summary
- update interface for cancellable reload background task
- implement `ReloadService` with cancellation and logging
- fix DataMigrationService using directive
- update RentalForm for async stop and new start signature

## Testing
- `dotnet test` *(fails: Microsoft.WindowsDesktop.App runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847aeab37ec832792c17b8b8b883b58