### PR TITLE
Add COMIC_DB_PATH override

### DIFF
--- a/ComicRentalSystem.Tests/DatabaseConfigTests.cs
+++ b/ComicRentalSystem.Tests/DatabaseConfigTests.cs
@@ -1,0 +1,44 @@
+using ComicRentalSystem_14Days.Helpers;
+using System;
+using System.IO;
+
+namespace ComicRentalSystem.Tests
+{
+    [TestClass]
+    public class DatabaseConfigTests
+    {
+        private string? _originalDbPath;
+        private string _tempPath = string.Empty;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _originalDbPath = Environment.GetEnvironmentVariable("COMIC_DB_PATH");
+            _tempPath = Path.Combine(Path.GetTempPath(), $"testdb_{Guid.NewGuid()}.db");
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Environment.SetEnvironmentVariable("COMIC_DB_PATH", _originalDbPath);
+            if (File.Exists(_tempPath))
+            {
+                File.Delete(_tempPath);
+            }
+            var dir = Path.GetDirectoryName(_tempPath);
+            if (!string.IsNullOrEmpty(dir) && Directory.Exists(dir) && Directory.GetFiles(dir).Length == 0)
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+
+        [TestMethod]
+        public void GetConnectionString_UsesEnvironmentVariable()
+        {
+            Environment.SetEnvironmentVariable("COMIC_DB_PATH", _tempPath);
+            var conn = DatabaseConfig.GetConnectionString();
+            Assert.AreEqual($"Data Source={_tempPath}", conn);
+            Assert.IsTrue(Directory.Exists(Path.GetDirectoryName(_tempPath)!));
+        }
+    }
+}

--- a/ComicRentalSystem_14Days/Helpers/DatabaseConfig.cs
+++ b/ComicRentalSystem_14Days/Helpers/DatabaseConfig.cs
@@ -10,6 +10,17 @@ namespace ComicRentalSystem_14Days.Helpers
 
         public static string GetConnectionString()
         {
+            var customPath = Environment.GetEnvironmentVariable("COMIC_DB_PATH");
+            if (!string.IsNullOrWhiteSpace(customPath))
+            {
+                var dir = Path.GetDirectoryName(customPath);
+                if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+                return $"Data Source={customPath}";
+            }
+
             string appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             string dbFolderPath = Path.Combine(appDataPath, AppFolderName);
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ B11170047陳家龢
     *   **資料庫檔案**：
         *   `comic_rental.db`：包含所有應用程式資料 (漫畫、會員、使用者帳號等)。
         *   此檔案位於使用者 `%APPDATA%\ComicRentalApp` 目錄下 (例如：`C:\Users\YourUsername\AppData\Roaming\ComicRentalApp\comic_rental.db`)。
+        *   亦可透過環境變數 `COMIC_DB_PATH` 指定其他資料庫檔案路徑。
         *   如果此資料庫檔案在應用程式首次執行時不存在，系統將會自動建立它。
     *   **日誌檔案目錄**：
         *   日誌檔案 (例如 `20231026.txt`) 儲存在使用者「我的文件」資料夾內的 `ComicRentalApp\Logs` 目錄下 (例如：`C:\Users\YourUsername\Documents\ComicRentalApp\Logs`)。


### PR DESCRIPTION
## Summary
- allow overriding DB path via `COMIC_DB_PATH` in `DatabaseConfig`
- document `COMIC_DB_PATH` in README
- add unit test for the override

## Testing
- `dotnet test` *(fails: Microsoft.WindowsDesktop.App not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847b0c559308327b6252b08cd1b096e