### PR TITLE
Fix login attempt persistence in AuthenticationService

### DIFF
--- a/ComicRentalSystem_14Days/Services/AuthenticationService.cs
+++ b/ComicRentalSystem_14Days/Services/AuthenticationService.cs
@@ -129,7 +129,14 @@ namespace ComicRentalSystem_14Days.Services
                     user.LockoutEndDate = DateTime.UtcNow.AddMinutes(LockoutDurationMinutes);
                     _logger.Log($"User '{username}' account locked until {user.LockoutEndDate.Value} due to missing salt and failed attempts.");
                 }
-                try { using var ctx = CreateContext(); ctx.SaveChanges(); } catch (DbUpdateException dbEx) { _logger.LogError($"Failed to save login attempt changes for user {username} (missing salt).", dbEx); }
+                try
+                {
+                    context.SaveChanges();
+                }
+                catch (DbUpdateException dbEx)
+                {
+                    _logger.LogError($"Failed to save login attempt changes for user {username} (missing salt).", dbEx);
+                }
                 return null;
             }
 
@@ -140,7 +147,14 @@ namespace ComicRentalSystem_14Days.Services
             {
                 user.FailedLoginAttempts = 0;
                 user.LockoutEndDate = null;
-                try { using var ctx = CreateContext(); ctx.SaveChanges(); } catch (DbUpdateException dbEx) { _logger.LogError($"Failed to save successful login changes for user {username}.", dbEx); }
+                try
+                {
+                    context.SaveChanges();
+                }
+                catch (DbUpdateException dbEx)
+                {
+                    _logger.LogError($"Failed to save successful login changes for user {username}.", dbEx);
+                }
                 _logger.Log($"Login successful for {username}, Role: {user.Role}");
                 return user;
             }
@@ -153,8 +167,15 @@ namespace ComicRentalSystem_14Days.Services
                     user.LockoutEndDate = DateTime.UtcNow.AddMinutes(LockoutDurationMinutes);
                     _logger.Log($"User '{username}' account locked until {user.LockoutEndDate.Value} due to too many failed login attempts.");
                 }
-                try { using var ctx = CreateContext(); ctx.SaveChanges(); } catch (DbUpdateException dbEx) { _logger.LogError($"Failed to save failed login attempt changes for user {username}.", dbEx); }
-                return null; 
+                try
+                {
+                    context.SaveChanges();
+                }
+                catch (DbUpdateException dbEx)
+                {
+                    _logger.LogError($"Failed to save failed login attempt changes for user {username}.", dbEx);
+                }
+                return null;
             }
         }
 


### PR DESCRIPTION
## Summary
- save failed login attempts using the same DbContext
- persist lockout/success updates without creating a new context

## Testing
- `dotnet test ComicRentalSystem.Tests/ComicRentalSystem.Tests.csproj -c Debug --no-build --logger "console;verbosity=normal"` *(fails: argument invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6847b2179cd483279af1ed93ff5b8cb8