### PR TITLE
Update My Rentals tab labels

### DIFF
--- a/ComicRentalSystem_14Days/MainForm.Designer.cs
+++ b/ComicRentalSystem_14Days/MainForm.Designer.cs
@@ -306,7 +306,7 @@ namespace ComicRentalSystem_14Days
             myRentalsTabPage.Padding = new Padding(8);
             myRentalsTabPage.Size = new Size(961, 554);
             myRentalsTabPage.TabIndex = 1;
-            myRentalsTabPage.Text = "我租的漫畫";
+            myRentalsTabPage.Text = "我租借的漫畫";
             dgvMyRentedComics.AllowUserToAddRows = false;
             dgvMyRentedComics.AllowUserToDeleteRows = false;
             dgvMyRentedComics.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;

--- a/ComicRentalSystem_14Days/MainForm.cs
+++ b/ComicRentalSystem_14Days/MainForm.cs
@@ -578,8 +578,8 @@ namespace ComicRentalSystem_14Days
             dgvMyRentedComics.Columns.Clear();
             dgvMyRentedComics.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
 
-            dgvMyRentedComics.Columns.Add(new DataGridViewTextBoxColumn { DataPropertyName = "ComicTitle", HeaderText = "書名", FillWeight = 30 });
-            dgvMyRentedComics.Columns.Add(new DataGridViewTextBoxColumn { DataPropertyName = "Author", HeaderText = "作者", FillWeight = 20 });
+            dgvMyRentedComics.Columns.Add(new DataGridViewTextBoxColumn { DataPropertyName = "ComicTitle", HeaderText = "漫畫名稱", FillWeight = 30 });
+            dgvMyRentedComics.Columns.Add(new DataGridViewTextBoxColumn { DataPropertyName = "Author", HeaderText = "漫畫作者", FillWeight = 20 });
 
             var rentalDateColumn = new DataGridViewTextBoxColumn
             {
@@ -594,7 +594,7 @@ namespace ComicRentalSystem_14Days
             var returnDateColumn = new DataGridViewTextBoxColumn
             {
                 DataPropertyName = "ExpectedReturnDate",
-                HeaderText = "歸還日期",
+                HeaderText = "應還日期",
                 FillWeight = 18
             };
             returnDateColumn.DefaultCellStyle ??= new DataGridViewCellStyle();
@@ -606,7 +606,7 @@ namespace ComicRentalSystem_14Days
                 var statusColumn = new DataGridViewTextBoxColumn
                 {
                     Name = "statusColumn",
-                    HeaderText = "狀態",
+                    HeaderText = "租借狀態",
                     FillWeight = 14
                 };
                 dgvMyRentedComics.Columns.Add(statusColumn);


### PR DESCRIPTION
## Summary
- translate My Rentals tab header
- translate rented comics grid columns

## Testing
- `dotnet test ComicRentalSystem_14Days.sln --no-build` *(fails: The argument is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6847bffb9cd883278cdec8d38dd69cac