### PR TITLE
Fix DataGrid headers translation for member view

### DIFF
--- a/ComicRentalSystem_14Days/MainForm.cs
+++ b/ComicRentalSystem_14Days/MainForm.cs
@@ -112,6 +112,10 @@ namespace ComicRentalSystem_14Days
             if (btnNavLogs != null) btnNavLogs.Click += btnNavLogs_Click;
 
             SetupDataGridView();
+            if (_currentUser.Role == UserRole.Member)
+            {
+                SetupMyRentedComicsDataGridView();
+            }
 
             if (_currentUser.Role == UserRole.Admin)
             {


### PR DESCRIPTION
## Summary
- configure My Rented Comics DataGrid when member logs in

## Testing
- `dotnet build ComicRentalSystem_14Days.sln`
- `dotnet test ComicRentalSystem_14Days.sln` *(fails: Microsoft.WindowsDesktop.App missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847c26097948327bcfaa5d9b95b034e