### PR TITLE
Fix duplicate controls in RentalForm

### DIFF
--- a/ComicRentalSystem_14Days/Forms/RentalForm.Designer.cs
+++ b/ComicRentalSystem_14Days/Forms/RentalForm.Designer.cs
@@ -4,8 +4,6 @@ namespace ComicRentalSystem_14Days.Forms
     {
         private System.ComponentModel.IContainer components = null;
 
-        private System.Windows.Forms.GroupBox grpRent;
-        private System.Windows.Forms.GroupBox grpReturn;
         private System.Windows.Forms.Label lblMember;
         private System.Windows.Forms.Label lblComic;
         private System.Windows.Forms.Label lblActualReturnTime;


### PR DESCRIPTION
## Summary
- remove duplicate `grpRent` and `grpReturn` declarations in RentalForm.Designer

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847d20fae8083278a916239b49728e7