### PR TITLE
Implement shortcut keys and input validations

### DIFF
--- a/ComicRentalSystem_14Days/Forms/ComicEditForm.cs
+++ b/ComicRentalSystem_14Days/Forms/ComicEditForm.cs
@@ -20,7 +20,9 @@ namespace ComicRentalSystem_14Days.Forms
         {
             InitializeComponent();
             this.errorProvider1 = new System.Windows.Forms.ErrorProvider();
-            if (this.DesignMode) 
+            this.KeyPreview = true;
+            this.KeyDown += ComicEditForm_KeyDown;
+            if (this.DesignMode)
             {
                 chkIsRented.Enabled = false;
             }
@@ -266,12 +268,21 @@ namespace ComicRentalSystem_14Days.Forms
         {
             if (sender is TextBox txt && string.IsNullOrWhiteSpace(txt.Text))
             {
-                errorProvider1?.SetError(txt, "類型不能為空。"); 
+                errorProvider1?.SetError(txt, "類型不能為空。");
                 e.Cancel = true;
             }
             else if (sender is TextBox txtBox)
             {
-                errorProvider1?.SetError(txtBox, ""); 
+                errorProvider1?.SetError(txtBox, "");
+            }
+        }
+
+        private void ComicEditForm_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Control && e.KeyCode == Keys.S)
+            {
+                btnSave_Click(sender!, e);
+                e.SuppressKeyPress = true;
             }
         }
     }

--- a/ComicRentalSystem_14Days/Forms/ComicManagementForm.cs
+++ b/ComicRentalSystem_14Days/Forms/ComicManagementForm.cs
@@ -17,6 +17,8 @@ namespace ComicRentalSystem_14Days.Forms
             InitializeComponent();
             _comicService = comicService;
             _currentUser = currentUser;
+            this.KeyPreview = true;
+            this.KeyDown += ComicManagementForm_KeyDown;
             SetupDataGridView();
             LoadComicsData();
             _comicService.ComicsChanged += ComicService_ComicsChanged;
@@ -364,6 +366,20 @@ namespace ComicRentalSystem_14Days.Forms
             bool rowSelected = dgvComics.SelectedRows.Count > 0;
             btnEditComic.Enabled = rowSelected;
             btnDeleteComic.Enabled = rowSelected;
+        }
+
+        private void ComicManagementForm_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Control && e.KeyCode == Keys.N)
+            {
+                btnAddComic_Click(sender!, e);
+                e.SuppressKeyPress = true;
+            }
+            else if (e.KeyCode == Keys.Delete)
+            {
+                btnDeleteComic_Click(sender!, e);
+                e.SuppressKeyPress = true;
+            }
         }
     }
 }

--- a/ComicRentalSystem_14Days/Forms/MemberEditForm.cs
+++ b/ComicRentalSystem_14Days/Forms/MemberEditForm.cs
@@ -20,6 +20,9 @@ namespace ComicRentalSystem_14Days.Forms
         {
             InitializeComponent();
             this.errorProvider1 = new System.Windows.Forms.ErrorProvider();
+            this.KeyPreview = true;
+            this.KeyDown += MemberEditForm_KeyDown;
+            this.txtPhoneNumber.KeyPress += txtPhoneNumber_KeyPress;
             if (this.DesignMode)
             {
             }
@@ -182,8 +185,25 @@ namespace ComicRentalSystem_14Days.Forms
                 }
                 else
                 {
-                    errorProvider1?.SetError(txt, ""); 
+                    errorProvider1?.SetError(txt, "");
                 }
+            }
+        }
+
+        private void txtPhoneNumber_KeyPress(object? sender, KeyPressEventArgs e)
+        {
+            if (!char.IsControl(e.KeyChar) && !char.IsDigit(e.KeyChar))
+            {
+                e.Handled = true;
+            }
+        }
+
+        private void MemberEditForm_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Control && e.KeyCode == Keys.S)
+            {
+                btnSaveMember_Click(sender!, e);
+                e.SuppressKeyPress = true;
             }
         }
     }

--- a/ComicRentalSystem_14Days/Forms/MemberManagementForm.cs
+++ b/ComicRentalSystem_14Days/Forms/MemberManagementForm.cs
@@ -18,6 +18,8 @@ namespace ComicRentalSystem_14Days.Forms
         public MemberManagementForm()
         {
             InitializeComponent();
+            this.KeyPreview = true;
+            this.KeyDown += MemberManagementForm_KeyDown;
         }
 
         public MemberManagementForm(ILogger logger, MemberService memberService, AuthenticationService authenticationService, IComicService comicService, User? currentUser) : base(logger)
@@ -27,6 +29,8 @@ namespace ComicRentalSystem_14Days.Forms
             _authenticationService = authenticationService ?? throw new ArgumentNullException(nameof(authenticationService));
             _comicService = comicService ?? throw new ArgumentNullException(nameof(comicService));
             _currentUser = currentUser;
+            this.KeyPreview = true;
+            this.KeyDown += MemberManagementForm_KeyDown;
             LogActivity("會員管理表單正在使用 MemberService、AuthenticationService 和 ComicService 初始化。");
         }
 
@@ -367,6 +371,20 @@ namespace ComicRentalSystem_14Days.Forms
             btnEditMember.Enabled = rowSelected;
             btnDeleteMember.Enabled = rowSelected;
             btnChangeUserRole.Enabled = rowSelected;
+        }
+
+        private void MemberManagementForm_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Control && e.KeyCode == Keys.N)
+            {
+                btnAddMember_Click(sender!, e);
+                e.SuppressKeyPress = true;
+            }
+            else if (e.KeyCode == Keys.Delete)
+            {
+                btnDeleteMember_Click(sender!, e);
+                e.SuppressKeyPress = true;
+            }
         }
     }
 }

--- a/ComicRentalSystem_14Days/Forms/RentalForm.cs
+++ b/ComicRentalSystem_14Days/Forms/RentalForm.cs
@@ -30,6 +30,8 @@ namespace ComicRentalSystem_14Days.Forms
         public RentalForm() : base()
         {
             InitializeComponent();
+            this.KeyPreview = true;
+            this.KeyDown += RentalForm_KeyDown;
         }
 
         public RentalForm(
@@ -44,6 +46,9 @@ namespace ComicRentalSystem_14Days.Forms
             _comicService = comicService ?? throw new ArgumentNullException(nameof(comicService));
             _memberService = memberService ?? throw new ArgumentNullException(nameof(memberService));
             _reloadService = reloadService ?? throw new ArgumentNullException(nameof(reloadService));
+
+            this.KeyPreview = true;
+            this.KeyDown += RentalForm_KeyDown;
 
             if (_comicService != null)
             {
@@ -87,6 +92,8 @@ namespace ComicRentalSystem_14Days.Forms
                 LogActivity("租借表單已成功載入資料。");
                 UpdateRentButtonState();
                 UpdateReturnButtonState();
+                dtpActualReturnTime.MaxDate = DateTime.Now;
+                dtpActualReturnTime.Value = DateTime.Now;
             }
             else
             {
@@ -299,6 +306,7 @@ namespace ComicRentalSystem_14Days.Forms
         dgvRentedComics.MultiSelect = false;
         dgvRentedComics.ReadOnly = true;
         dgvRentedComics.AllowUserToAddRows = false;
+        dgvRentedComics.CellDoubleClick += dgvRentedComics_CellDoubleClick;
         LogActivity("dgvRentedComics 管理員視圖設定完成。");
     }
 
@@ -496,6 +504,7 @@ namespace ComicRentalSystem_14Days.Forms
             LogActivity($"漫畫 '{comicFromService.Title}' (ID: {comicFromService.Id}) 已成功歸還 (由會員 '{returningMemberName}' 租借)。");
             MessageBox.Show($"漫畫 '{comicFromService.Title}' 已成功歸還。", "歸還成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
             LoadRentalDetails();
+            dtpActualReturnTime.MaxDate = DateTime.Now;
             dtpActualReturnTime.Value = DateTime.Now;
             UpdateReturnButtonState();
         }
@@ -509,6 +518,23 @@ namespace ComicRentalSystem_14Days.Forms
         private void dgvRentedComics_SelectionChanged(object sender, EventArgs e)
         {
             UpdateReturnButtonState();
+        }
+
+        private void dgvRentedComics_CellDoubleClick(object sender, DataGridViewCellEventArgs e)
+        {
+            if (e.RowIndex >= 0)
+            {
+                btnReturn_Click(sender, e);
+            }
+        }
+
+        private void RentalForm_KeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Delete)
+            {
+                btnReturn_Click(sender!, e);
+                e.SuppressKeyPress = true;
+            }
         }
 
         protected override async void OnFormClosing(FormClosingEventArgs e)


### PR DESCRIPTION
## Summary
- add keyboard shortcuts for add/save/delete actions
- filter phone number input to digits only
- set default and max dates when returning comics
- enable quick return via double-click

## Testing
- `dotnet test` *(fails: missing Microsoft.WindowsDesktop.App)*

------
https://chatgpt.com/codex/tasks/task_e_6847e1bd2d1483278f1ffe0df347f227