### PR TITLE
Improve error messages

### DIFF
--- a/ComicRentalSystem_14Days/Forms/ComicEditForm.cs
+++ b/ComicRentalSystem_14Days/Forms/ComicEditForm.cs
@@ -110,7 +110,7 @@ namespace ComicRentalSystem_14Days.Forms
         {
             if (_comicService == null)
             {
-                MessageBox.Show("服務未初始化，無法儲存。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show("系統發生異常，請重新啟動應用程式。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 LogErrorActivity("儲存按鈕已點擊，但 _comicService 為空。");
                 return;
             }

--- a/ComicRentalSystem_14Days/Forms/MemberEditForm.cs
+++ b/ComicRentalSystem_14Days/Forms/MemberEditForm.cs
@@ -79,7 +79,7 @@ namespace ComicRentalSystem_14Days.Forms
         {
             if (_memberService == null)
             {
-                MessageBox.Show("服務未初始化，無法儲存。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show("系統發生異常，請重新啟動應用程式。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 LogErrorActivity("儲存會員按鈕已點擊，但 _memberService 為空。");
                 return;
             }

--- a/ComicRentalSystem_14Days/Forms/MemberManagementForm.cs
+++ b/ComicRentalSystem_14Days/Forms/MemberManagementForm.cs
@@ -181,7 +181,7 @@ namespace ComicRentalSystem_14Days.Forms
             if (_memberService == null || Logger == null || _authenticationService == null)
             {
                 LogErrorActivity("新增會員所需的基本服務不可用。", new InvalidOperationException("服務未初始化。"));
-                MessageBox.Show("無法開啟註冊表單，必要的服務未初始化。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show("系統發生異常，請重新啟動應用程式。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
             LogActivity("新增會員按鈕已點擊。正在為新會員開啟 RegistrationForm。");
@@ -254,9 +254,9 @@ namespace ComicRentalSystem_14Days.Forms
                     }
                     else
                     {
-                        MessageBox.Show("無法檢查會員租借狀態，漫畫服務未初始化。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox.Show("系統發生異常，請重新啟動應用程式。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         LogErrorActivity("Could not check member rental status: _comicService is null.");
-                        return; 
+                        return;
                     }
 
                     LogActivity($"嘗試刪除會員 ID: {selectedMember.Id}，姓名: '{selectedMember.Name}'。正在顯示確認對話方塊。");
@@ -330,9 +330,9 @@ namespace ComicRentalSystem_14Days.Forms
                 MessageBox.Show("請選擇一位會員。", "未選擇會員", MessageBoxButtons.OK, MessageBoxIcon.Information); 
                 return;
             }
-            if (_authenticationService == null || Logger == null) 
+            if (_authenticationService == null || Logger == null)
             {
-                 MessageBox.Show("必要的服務不可用。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error); 
+                 MessageBox.Show("系統發生異常，請重新啟動應用程式。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
                  LogErrorActivity("變更使用者角色所需服務不可用。", new InvalidOperationException("服務未初始化。"));
                  return;
             }

--- a/ComicRentalSystem_14Days/Forms/RegistrationForm.cs
+++ b/ComicRentalSystem_14Days/Forms/RegistrationForm.cs
@@ -118,7 +118,14 @@ namespace ComicRentalSystem_14Days.Forms
             else
             {
                 _logger.Log($"使用者 '{username}' 註冊失敗。使用者名稱可能已存在。");
-                MessageBox.Show("無法完成註冊。請確認所有欄位均已正確填寫，或嘗試使用不同的使用者名稱。", "註冊失敗", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                if (_authService.GetUserByUsername(username) != null)
+                {
+                    MessageBox.Show("使用者名稱已被使用，請換一個試試。", "註冊失敗", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                }
+                else
+                {
+                    MessageBox.Show("無法完成註冊，請稍後再試。", "註冊失敗", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
                 txtUsername.Clear();
             }
         }

--- a/ComicRentalSystem_14Days/Forms/RentalForm.cs
+++ b/ComicRentalSystem_14Days/Forms/RentalForm.cs
@@ -332,7 +332,7 @@ namespace ComicRentalSystem_14Days.Forms
         {
             if (_comicService == null || _memberService == null)
             {
-                MessageBox.Show("服務未初始化，無法執行操作。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show("系統發生異常，請重新啟動應用程式。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
             LogActivity("租借按鈕已點擊。");
@@ -451,7 +451,7 @@ namespace ComicRentalSystem_14Days.Forms
 
         if (_comicService == null || _memberService == null)
         {
-            MessageBox.Show("服務未初始化，無法執行操作。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBox.Show("系統發生異常，請重新啟動應用程式。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
             return;
         }
         LogActivity("歸還按鈕已點擊。"); 

--- a/ComicRentalSystem_14Days/MainForm.cs
+++ b/ComicRentalSystem_14Days/MainForm.cs
@@ -782,13 +782,13 @@ namespace ComicRentalSystem_14Days
                 }
                 else
                 {
-                    MessageBox.Show("Logger, AuthenticationService, 或 MemberService 未初始化，無法開啟使用者註冊。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show("系統發生異常，請重新啟動應用程式。", "錯誤", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     this._logger?.LogError("由於 logger、AppAuthService 或 _memberService 為空，無法開啟註冊表單。");
                 }
             }
             else
             {
-                MessageBox.Show("只有管理員才能註冊新使用者。", "權限不足", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                MessageBox.Show("只有管理員才能註冊新使用者。\n請以管理員身份登入後再試。", "警告", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 this._logger?.Log($"非管理員使用者 '{_currentUser.Username}' 嘗試開啟註冊表單。");
             }
         }
@@ -828,7 +828,7 @@ namespace ComicRentalSystem_14Days
             else
             {
                 this._logger?.Log($"使用者 '{_currentUser.Username}' (角色: {_currentUser.Role}) 嘗試檢視日誌。權限不足。");
-                MessageBox.Show("權限不足", "提示", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                MessageBox.Show("權限不足，請以管理員身份登入執行此操作。", "警告", MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
         }
 
@@ -841,7 +841,7 @@ namespace ComicRentalSystem_14Days
             }
             else
             {
-                MessageBox.Show("權限不足", "提示", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                MessageBox.Show("權限不足，請以管理員身份登入執行此操作。", "警告", MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
         }
 


### PR DESCRIPTION
## Summary
- clarify duplicate-username messages in `RegistrationForm`
- use a consistent warning style for insufficient privilege prompts
- show user-friendly failure messages when services aren't initialized

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e7026210832788d23e533fb19484