### PR TITLE
Fix user role update persistence

### DIFF
--- a/ComicRentalSystem_14Days/Forms/ChangeUserRoleForm.cs
+++ b/ComicRentalSystem_14Days/Forms/ChangeUserRoleForm.cs
@@ -61,7 +61,7 @@ namespace ComicRentalSystem_14Days.Forms
 
             try
             {
-                _authService.SaveUsers();
+                _authService.SaveUser(_editingUser);
                 LogActivity($"已成功將使用者 '{_editingUser.Username}' 的角色變更為 {newRole}。");
                 MessageBox.Show("使用者角色已成功更新。", "成功", MessageBoxButtons.OK, MessageBoxIcon.Information); 
                 this.DialogResult = DialogResult.OK;

--- a/ComicRentalSystem_14Days/Services/AuthenticationService.cs
+++ b/ComicRentalSystem_14Days/Services/AuthenticationService.cs
@@ -226,10 +226,22 @@ namespace ComicRentalSystem_14Days.Services
             }
         }
 
-        public void SaveUsers()
+        public void SaveUser(User user)
         {
-            _logger.Log("透過 AuthenticationService.SaveUsers() 將使用者變更寫入資料庫。");
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            _logger.Log($"透過 AuthenticationService.SaveUser() 將使用者 '{user.Username}' 的變更寫入資料庫。");
             using var context = CreateContext();
+            var existingUser = context.Users.FirstOrDefault(u => u.Id == user.Id);
+            if (existingUser == null)
+            {
+                _logger.LogWarning($"User with ID {user.Id} not found. Save aborted.");
+                throw new InvalidOperationException($"User with ID {user.Id} not found.");
+            }
+            context.Entry(existingUser).CurrentValues.SetValues(user);
             context.SaveChanges();
         }
     }


### PR DESCRIPTION
## Summary
- persist user role changes to the database
- update role-change form to use new save method

## Testing
- `dotnet build ComicRentalSystem_14Days.sln -c Release -v minimal`
- `dotnet test ComicRentalSystem_14Days.sln --no-build` *(fails: The argument is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6847eaa78ac48327a8042ae2ce7f6171