### PR TITLE
Add guard when member with rentals becomes admin

### DIFF
--- a/ComicRentalSystem_14Days/Forms/MemberManagementForm.cs
+++ b/ComicRentalSystem_14Days/Forms/MemberManagementForm.cs
@@ -354,7 +354,7 @@ namespace ComicRentalSystem_14Days.Forms
             }
 
             LogActivity($"Opening ChangeUserRoleForm for member '{selectedMember.Name}', user '{userToEdit.Username}'.");
-            using (ChangeUserRoleForm changeRoleForm = new ChangeUserRoleForm(userToEdit, _authenticationService, Logger))
+            using (ChangeUserRoleForm changeRoleForm = new ChangeUserRoleForm(userToEdit, selectedMember, _authenticationService, _comicService!, Logger))
             {
                 changeRoleForm.ShowDialog(this);
             }


### PR DESCRIPTION
## Summary
- block changing a user to admin while they still have active rentals
- wire comic service and member into ChangeUserRoleForm

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ec90dee88327959aeabee3ae30a0