### PR TITLE
Improve member and rental validation

### DIFF
--- a/ComicRentalSystem_14Days/Forms/RentalForm.cs
+++ b/ComicRentalSystem_14Days/Forms/RentalForm.cs
@@ -493,11 +493,17 @@ namespace ComicRentalSystem_14Days.Forms
 
         try
         {
-                int previouslyRentedByMemberId = comicFromService.RentedToMemberId; 
+            if (comicFromService.RentalDate.HasValue && dtpActualReturnTime.Value < comicFromService.RentalDate.Value)
+            {
+                MessageBox.Show("實際歸還時間不能早於租借日期。", "日期錯誤", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            int previouslyRentedByMemberId = comicFromService.RentedToMemberId;
             comicFromService.IsRented = false;
             comicFromService.RentedToMemberId = 0;
-                comicFromService.ActualReturnTime = dtpActualReturnTime.Value; 
-                _comicService?.UpdateComic(comicFromService);
+            comicFromService.ActualReturnTime = dtpActualReturnTime.Value;
+            _comicService?.UpdateComic(comicFromService);
 
             Member? returningMember = _memberService?.GetMemberById(previouslyRentedByMemberId);
             string returningMemberName = returningMember?.Name ?? $"ID: {previouslyRentedByMemberId}";

--- a/ComicRentalSystem_14Days/Services/MemberService.cs
+++ b/ComicRentalSystem_14Days/Services/MemberService.cs
@@ -87,6 +87,14 @@ namespace ComicRentalSystem_14Days.Services
             {
                 _logger.LogWarning($"AddMember: Member with phone number '{member.PhoneNumber}' already exists.");
             }
+
+            if (!string.IsNullOrWhiteSpace(member.Username) &&
+                context.Members.Any(m => m.Username != null && m.Username.ToLower() == member.Username.ToLower()))
+            {
+                var ex = new InvalidOperationException($"A member with username '{member.Username}' already exists.");
+                _logger.LogError($"AddMember failed: Username '{member.Username}' already exists.", ex);
+                throw ex;
+            }
             context.Members.Add(member);
             try
             {
@@ -123,6 +131,14 @@ namespace ComicRentalSystem_14Days.Services
             if (context.Members.Any(m => m.PhoneNumber == member.PhoneNumber && m.Id != member.Id))
             {
                  _logger.LogWarning($"UpdateMember: Another member with phone number '{member.PhoneNumber}' already exists.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(member.Username) &&
+                context.Members.Any(m => m.Username != null && m.Username.ToLower() == member.Username.ToLower() && m.Id != member.Id))
+            {
+                var ex = new InvalidOperationException($"Username '{member.Username}' is already taken by another member.");
+                _logger.LogError($"UpdateMember failed for ID {member.Id}: username duplicate.", ex);
+                throw ex;
             }
 
             context.Entry(existingMember).CurrentValues.SetValues(member);


### PR DESCRIPTION
## Summary
- add duplicate username validation when adding or updating members
- ensure return time cannot be before rental date

## Testing
- `dotnet build ComicRentalSystem_14Days.sln -c Release`
- `dotnet test ComicRentalSystem_14Days.sln` *(fails: missing Microsoft.WindowsDesktop runtime)*

------
https://chatgpt.com/codex/tasks/task_e_6847ee3229648327abf92588c63cffb8